### PR TITLE
UIINREACH-36: Configure FOLIO Libraries and Shelving Locations to INN-Reach Locations Mapping - create/edit backend integration

### DIFF
--- a/src/constants/base.js
+++ b/src/constants/base.js
@@ -6,6 +6,7 @@ export const SETTINGS_PATH = `${SETTINGS}/${MODULE_ROUTE}`;
 export const SETTINGS_PANE_WIDTH = '15%';
 export const DEFAULT_PANE_WIDTH = '65%';
 export const FILL_PANE_WIDTH = 'fill';
+export const METADATA = 'metadata';
 
 export const CALLOUT_ERROR_TYPE = 'error';
 

--- a/src/settings/routes/ContributionCriteriaRoute/ContributionCriteriaCreateEditRoute.js
+++ b/src/settings/routes/ContributionCriteriaRoute/ContributionCriteriaCreateEditRoute.js
@@ -210,6 +210,7 @@ ContributionCriteriaCreateEditRoute.manifest = Object.freeze({
     POST: {
       path: 'inn-reach/central-servers/contribution-criteria',
     },
+    clientGeneratePk: false,
     accumulate: true,
     fetch: false,
     throwErrors: false,

--- a/src/settings/routes/ContributionCriteriaRoute/ContributionCriteriaCreateEditRoute.js
+++ b/src/settings/routes/ContributionCriteriaRoute/ContributionCriteriaCreateEditRoute.js
@@ -6,6 +6,7 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import PropTypes from 'prop-types';
 import {
   omit,
+  isEmpty,
 } from 'lodash';
 import {
   FormattedMessage,
@@ -20,6 +21,7 @@ import { stripesConnect } from '@folio/stripes/core';
 import {
   CALLOUT_ERROR_TYPE,
   CONTRIBUTION_CRITERIA,
+  METADATA,
 } from '../../../constants';
 import ContributionCriteriaForm from '../../components/ContributionCriteria/ContributionCriteriaForm';
 import {
@@ -41,6 +43,7 @@ const ContributionCriteriaCreateEditRoute = ({
     centralServerRecords: {
       records: centralServers,
       isPending: isServersPending,
+      hasLoaded: hasLoadedServers,
     },
     folioLocations: {
       records: locations,
@@ -70,7 +73,7 @@ const ContributionCriteriaCreateEditRoute = ({
     handleModalCancel,
   ] = useCentralServers(history, servers);
   const showCallout = useCallout();
-  const [contributionCriteria, setContributionCriteria] = useState(null);
+  const [contributionCriteria, setContributionCriteria] = useState({});
   const [initialValues, setInitialValues] = useState(DEFAULT_VALUES);
   const [isContributionCriteriaPending, setIsContributionCriteriaPending] = useState(false);
 
@@ -78,13 +81,19 @@ const ContributionCriteriaCreateEditRoute = ({
   const statisticalCodeTypes = statisticalCodeTypesData[0]?.statisticalCodeTypes || [];
   const statisticalCodes = statisticalCodesData[0]?.statisticalCodes || [];
 
+  const fetchContributionCriteria = () => {
+    mutator.contributionCriteria.GET()
+      .then(response => setContributionCriteria(response))
+      .catch(() => null)
+      .finally(() => setIsContributionCriteriaPending(false));
+  };
+
   const handleSubmit = (record) => {
-    const saveMethod = contributionCriteria
-      ? mutator.contributionCriteria.PUT
-      : mutator.contributionCriteriaCreate.POST;
+    const { contributionCriteria: { POST, PUT } } = mutator;
+    const saveMethod = isEmpty(contributionCriteria) ? POST : PUT;
     const FOLIOLocations = record[LOCATIONS_IDS];
     const finalRecord = {
-      ...omit(record, LOCATIONS_IDS),
+      ...omit(record, LOCATIONS_IDS, METADATA),
       centralServerId: selectedServer.id,
     };
 
@@ -94,12 +103,13 @@ const ContributionCriteriaCreateEditRoute = ({
 
     saveMethod(finalRecord)
       .then(() => {
-        const action = contributionCriteria ? 'update' : 'create';
+        const action = isEmpty(contributionCriteria) ? 'create' : 'update';
 
+        fetchContributionCriteria();
         showCallout({ message: <FormattedMessage id={`ui-inn-reach.settings.contribution-criteria.${action}.success`} /> });
       })
       .catch(() => {
-        const action = contributionCriteria ? 'put' : 'post';
+        const action = isEmpty(contributionCriteria) ? 'post' : 'put';
 
         showCallout({
           type: CALLOUT_ERROR_TYPE,
@@ -111,17 +121,15 @@ const ContributionCriteriaCreateEditRoute = ({
   useEffect(() => {
     if (selectedServer.id) {
       mutator.selectedServerId.replace(selectedServer.id);
+      setInitialValues(DEFAULT_VALUES);
+      setContributionCriteria({});
       setIsContributionCriteriaPending(true);
-
-      mutator.contributionCriteria.GET()
-        .then(response => setContributionCriteria(response))
-        .catch(() => null)
-        .finally(() => setIsContributionCriteriaPending(false));
+      fetchContributionCriteria();
     }
   }, [selectedServer]);
 
   useEffect(() => {
-    if (contributionCriteria) {
+    if (!isEmpty(contributionCriteria)) {
       const locationIds = contributionCriteria[LOCATIONS_IDS];
       const originalValues = {
         ...DEFAULT_VALUES,
@@ -141,7 +149,7 @@ const ContributionCriteriaCreateEditRoute = ({
     }
   }, [contributionCriteria]);
 
-  if (isServersPending) return <LoadingPane />;
+  if (isServersPending && !hasLoadedServers) return <LoadingPane />;
 
   return (
     <>
@@ -199,13 +207,9 @@ ContributionCriteriaCreateEditRoute.manifest = Object.freeze({
   contributionCriteria: {
     type: 'okapi',
     path: 'inn-reach/central-servers/%{selectedServerId}/contribution-criteria',
-    accumulate: true,
-    fetch: false,
-    throwErrors: false,
-  },
-  contributionCriteriaCreate: {
-    type: 'okapi',
-    path: 'inn-reach/central-servers/contribution-criteria',
+    POST: {
+      path: 'inn-reach/central-servers/contribution-criteria',
+    },
     accumulate: true,
     fetch: false,
     throwErrors: false,
@@ -219,6 +223,7 @@ ContributionCriteriaCreateEditRoute.propTypes = {
     centralServerRecords: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object).isRequired,
       isPending: PropTypes.bool.isRequired,
+      hasLoaded: PropTypes.bool.isRequired,
     }).isRequired,
     folioLocations: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -238,9 +243,6 @@ ContributionCriteriaCreateEditRoute.propTypes = {
       GET: PropTypes.func,
       POST: PropTypes.func,
       PUT: PropTypes.func,
-    }).isRequired,
-    contributionCriteriaCreate: PropTypes.shape({
-      POST: PropTypes.func,
     }).isRequired,
   }),
 };

--- a/src/settings/routes/ContributionCriteriaRoute/ContributionCriteriaCreateEditRoute.test.js
+++ b/src/settings/routes/ContributionCriteriaRoute/ContributionCriteriaCreateEditRoute.test.js
@@ -4,7 +4,7 @@ import {
   omit,
 } from 'lodash';
 import { createMemoryHistory } from 'history';
-import { waitFor, screen } from '@testing-library/react';
+import { waitFor, screen, act } from '@testing-library/react';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 import { ConfirmationModal } from '@folio/stripes-components';
@@ -106,6 +106,7 @@ const resourcesMock = {
   centralServerRecords: {
     records: servers,
     isPending: false,
+    hasLoaded: false,
   },
   folioLocations: {
     records: [{ locations }],
@@ -130,8 +131,6 @@ const mutatorMock = {
   contributionCriteria: {
     GET: getMock,
     PUT: putMock,
-  },
-  contributionCriteriaCreate: {
     POST: postMock,
   },
 };
@@ -220,10 +219,8 @@ describe('ContributionCriteriaCreateEditRoute component', () => {
     const finalRecord = contributionCriteria;
 
     it('should cause POST request', async () => {
-      await waitFor(() => {
-        renderContributionCriteriaCreateEditRoute({ history });
-      });
-      ContributionCriteriaForm.mock.calls[3][0].onSubmit(record);
+      await act(async () => { await renderContributionCriteriaCreateEditRoute({ history }); });
+      await act(async () => { await ContributionCriteriaForm.mock.calls[3][0].onSubmit(record); });
       expect(postMock).toHaveBeenCalledWith(finalRecord);
     });
 
@@ -232,13 +229,13 @@ describe('ContributionCriteriaCreateEditRoute component', () => {
 
       newMutator.contributionCriteria.GET = jest.fn(() => Promise.resolve({ contributionCriteria }));
 
-      await waitFor(() => {
-        renderContributionCriteriaCreateEditRoute({
+      await act(async () => {
+        await renderContributionCriteriaCreateEditRoute({
           history,
           mutator: newMutator,
         });
       });
-      ContributionCriteriaForm.mock.calls[3][0].onSubmit(record);
+      await act(async () => { await ContributionCriteriaForm.mock.calls[3][0].onSubmit(record); });
       expect(putMock).toHaveBeenCalledWith(finalRecord);
     });
   });

--- a/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.test.js
+++ b/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.test.js
@@ -141,30 +141,22 @@ const recordForLibrariesMappings = {
 
 const locationMappings = [
   {
-    locationMappings: [
-      {
-        id: '2',
-        locationId: 'ff357dab-1446-4e34-a78c-cf0478a10c75',
-        innReachLocationId: '7fab623d-1947-4413-b315-eae9ba9bb0c0',
-      },
-    ],
+    id: '2',
+    locationId: 'ff357dab-1446-4e34-a78c-cf0478a10c75',
+    innReachLocationId: '7fab623d-1947-4413-b315-eae9ba9bb0c0',
   },
 ];
 
 const libraryMappings = [
   {
-    libraryMappings: [
-      {
-        id: '1',
-        libraryId: '70cf3473-77f2-4f5c-92c3-6489e65769e4',
-        innReachLocationId: 'feafa30d-0b0c-43e3-a283-5344bd0ae5ab',
-      },
-      {
-        id: '2',
-        libraryId: '0939ebc4-cf37-4968-841e-912c0c02eacf',
-        innReachLocationId: '7fab623d-1947-4413-b315-eae9ba9bb0c0',
-      },
-    ],
+    id: '1',
+    libraryId: '70cf3473-77f2-4f5c-92c3-6489e65769e4',
+    innReachLocationId: 'feafa30d-0b0c-43e3-a283-5344bd0ae5ab',
+  },
+  {
+    id: '2',
+    libraryId: '0939ebc4-cf37-4968-841e-912c0c02eacf',
+    innReachLocationId: '7fab623d-1947-4413-b315-eae9ba9bb0c0',
   },
 ];
 
@@ -290,9 +282,9 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
   describe('Initial values', () => {
     it('should be with the folio libraries only', async () => {
       renderFolioToInnReachLocationsCreateEditRoute({ history });
-      act(() => { FolioToInnReachLocationsForm.mock.calls[0][0].onChangeServer(servers[0].name); });
+      act(() => { FolioToInnReachLocationsForm.mock.calls[1][0].onChangeServer(servers[0].name); });
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[3][0].onChangeMappingType('Libraries'); });
-      expect(FolioToInnReachLocationsForm.mock.calls[7][0].initialValues).toEqual({
+      expect(FolioToInnReachLocationsForm.mock.calls[6][0].initialValues).toEqual({
         tabularList: [
           { folioLibrary: 'newLib (QWER)' },
           { folioLibrary: 'test library (l)' }
@@ -301,20 +293,16 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
     });
 
     it('should be with the folio libraries and the inn reach locations', async () => {
-      const getLibraryMappings = jest.fn(() => Promise.resolve(libraryMappings));
+      const getLibraryMappings = jest.fn(() => Promise.resolve({ libraryMappings }));
       const newMutator = cloneDeep(mutatorMock);
 
       newMutator.libraryMappings.GET = getLibraryMappings;
-
       renderFolioToInnReachLocationsCreateEditRoute({
         history,
         mutator: newMutator,
       });
-      console.log('ll', FolioToInnReachLocationsForm.mock.calls.length)
       act(() => { FolioToInnReachLocationsForm.mock.calls[1][0].onChangeServer(servers[0].name); });
-      console.log('ll2', FolioToInnReachLocationsForm.mock.calls.length)
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[3][0].onChangeMappingType('Libraries'); });
-      console.log('ll3', FolioToInnReachLocationsForm.mock.calls.length)
       expect(FolioToInnReachLocationsForm.mock.calls[7][0].initialValues).toEqual(recordForLibrariesMappings);
     });
 
@@ -328,7 +316,7 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
       });
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[1][0].onChangeMappingType('Locations'); });
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[2][0].onChangeLibrary(loclibs[1].name); });
-      expect(FolioToInnReachLocationsForm.mock.calls[6][0].initialValues).toEqual({
+      expect(FolioToInnReachLocationsForm.mock.calls[5][0].initialValues).toEqual({
         tabularList: [
           { folioLocation: 'folioName5 (code5)' },
           { folioLocation: 'FOLIOname1 (7sdfe)' }
@@ -337,7 +325,7 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
     });
 
     it('should be with the folio locations and the inn reach locations', async () => {
-      const getLocationMappings = jest.fn(() => Promise.resolve(locationMappings));
+      const getLocationMappings = jest.fn(() => Promise.resolve({ locationMappings }));
       const newMutator = cloneDeep(mutatorMock);
 
       newMutator.locationMappings.GET = getLocationMappings;
@@ -396,13 +384,13 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
       renderFolioToInnReachLocationsCreateEditRoute({ history });
       act(() => { FolioToInnReachLocationsForm.mock.calls[1][0].onChangePristineState(false); });
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[2][0].onChangeLibrary(loclibs[1].name); });
-      await act(async () => { await FolioToInnReachLocationsForm.mock.calls[5][0].onChangeLibrary(loclibs[0].name); });
-      expect(ConfirmationModal.mock.calls[6][0].open).toBeTruthy();
+      await act(async () => { await FolioToInnReachLocationsForm.mock.calls[4][0].onChangeLibrary(loclibs[0].name); });
+      expect(ConfirmationModal.mock.calls[5][0].open).toBeTruthy();
     });
   });
 
   describe('handleSubmit', () => {
-    it('should make PUT for the location mappings', () => {
+    it('should make PUT for the location mappings', async () => {
       renderFolioToInnReachLocationsCreateEditRoute({
         history,
         resources: {
@@ -411,7 +399,7 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
         },
       });
       act(() => { FolioToInnReachLocationsForm.mock.calls[1][0].onChangeMappingType('Locations'); });
-      act(() => { FolioToInnReachLocationsForm.mock.calls[2][0].onSubmit(recordForLocationMappings); });
+      await act(async () => { await FolioToInnReachLocationsForm.mock.calls[2][0].onSubmit(recordForLocationMappings); });
       expect(mutatorMock.locationMappings.PUT).toHaveBeenCalledWith({
         locationMappings: [
           {
@@ -471,7 +459,7 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
         });
 
         it('should change the mapping type', () => {
-          expect(FolioToInnReachLocationsForm.mock.calls[8][0].mappingType).toEqual('Libraries');
+          expect(FolioToInnReachLocationsForm.mock.calls[7][0].mappingType).toEqual('Libraries');
         });
 
         it('should make GET request for the library mappings', () => {
@@ -479,11 +467,11 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
         });
 
         it('should reset the form', () => {
-          expect(FolioToInnReachLocationsForm.mock.calls[8][0].isResetForm).toBeTruthy();
+          expect(FolioToInnReachLocationsForm.mock.calls[7][0].isResetForm).toBeTruthy();
         });
 
         it('should close modal window', () => {
-          expect(ConfirmationModal.mock.calls[8][0].open).toBeFalsy();
+          expect(ConfirmationModal.mock.calls[7][0].open).toBeFalsy();
         });
       });
 
@@ -517,11 +505,11 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
       });
 
       it('should reset the form', () => {
-        expect(FolioToInnReachLocationsForm.mock.calls[9][0].isResetForm).toBeTruthy();
+        expect(FolioToInnReachLocationsForm.mock.calls[8][0].isResetForm).toBeTruthy();
       });
 
       it('should close modal window', () => {
-        expect(ConfirmationModal.mock.calls[9][0].open).toBeFalsy();
+        expect(ConfirmationModal.mock.calls[8][0].open).toBeFalsy();
       });
     });
 

--- a/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.test.js
+++ b/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.test.js
@@ -174,11 +174,13 @@ const resourcesMock = {
     records: [{ centralServers: servers }],
     isPending: false,
     failed: false,
+    hasLoaded: false,
   },
   innReachLocations: {
     records: [{ locations: innReachLocations }],
     isPending: false,
     failed: false,
+    hasLoaded: false,
   },
   folioLibraries: {
     records: [{ loclibs }],
@@ -257,8 +259,8 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
     it('should open modal window', async () => {
       renderFolioToInnReachLocationsCreateEditRoute({ history });
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[1][0].onChangeMappingType('Libraries'); });
-      act(() => { FolioToInnReachLocationsForm.mock.calls[5][0].onChangeServer(servers[0].name); });
-      expect(ConfirmationModal.mock.calls[6][0].open).toBeTruthy();
+      act(() => { FolioToInnReachLocationsForm.mock.calls[4][0].onChangeServer(servers[0].name); });
+      expect(ConfirmationModal.mock.calls[5][0].open).toBeTruthy();
     });
 
     it('should change selected server', () => {
@@ -308,8 +310,11 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
         history,
         mutator: newMutator,
       });
-      act(() => { FolioToInnReachLocationsForm.mock.calls[0][0].onChangeServer(servers[0].name); });
+      console.log('ll', FolioToInnReachLocationsForm.mock.calls.length)
+      act(() => { FolioToInnReachLocationsForm.mock.calls[1][0].onChangeServer(servers[0].name); });
+      console.log('ll2', FolioToInnReachLocationsForm.mock.calls.length)
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[3][0].onChangeMappingType('Libraries'); });
+      console.log('ll3', FolioToInnReachLocationsForm.mock.calls.length)
       expect(FolioToInnReachLocationsForm.mock.calls[7][0].initialValues).toEqual(recordForLibrariesMappings);
     });
 


### PR DESCRIPTION
- removed metadata
- made the Save button disabled after a successful request
- updated field values when changing the central server
- removed unexpecting LoadingPane component loading
- changed paths for library and location mappings