### PR TITLE
UIINREACH-37: The modal does not show up, when leaving the page

### DIFF
--- a/src/hooks/useCentralServers/useCentralServers.js
+++ b/src/hooks/useCentralServers/useCentralServers.js
@@ -1,24 +1,23 @@
-import React, { useEffect, useState } from 'react';
-import { CONTRIBUTION_CRITERIA } from '../../constants';
-
-const {
-  CENTRAL_SERVER_ID,
-} = CONTRIBUTION_CRITERIA;
+import React, {
+  useEffect,
+  useRef,
+  useState,
+  useMemo,
+} from 'react';
 
 const useCentralServers = (history, servers) => {
   const [selectedServer, setSelectedServer] = useState({});
   const [isPristine, setIsPristine] = useState(true);
-  const [prevServerName, setPrevServerName] = useState('');
-  const [nextServer, setNextServer] = useState('');
   const [openModal, setOpenModal] = useState(false);
   const [nextLocation, setNextLocation] = useState(null);
   const [isResetForm, setIsResetForm] = useState(false);
+  const unblockRef = useRef();
 
-  const serverOptions = servers.map(({ id, name }) => ({
+  const serverOptions = useMemo(() => servers.map(({ id, name }) => ({
     id,
     value: name,
     label: name,
-  }));
+  })), [servers]);
 
   const changePristineState = (value) => {
     setIsPristine(value);
@@ -29,69 +28,41 @@ const useCentralServers = (history, servers) => {
   };
 
   const handleServerChange = (selectedServerName) => {
+    if (selectedServerName === selectedServer.name) return;
     const optedServer = servers.find(server => server.name === selectedServerName);
-    const isNewServerSelected = selectedServerName !== selectedServer.name;
 
-    if (isNewServerSelected) {
-      if (isPristine) {
-        setSelectedServer(optedServer);
-      } else {
-        setOpenModal(true);
-        setNextServer(optedServer);
-      }
-
-      setPrevServerName(selectedServer.name);
-    }
-  };
-
-  const backPrevServer = () => {
-    const index = servers.findIndex(server => server.name === prevServerName);
-    const prevOption = document.getElementById(`option-${CENTRAL_SERVER_ID}-${index}-${prevServerName}`);
-
-    if (prevOption) prevOption.click();
+    setSelectedServer(optedServer);
   };
 
   const handleModalConfirm = () => {
-    if (prevServerName) { // if a new central server was selected
-      backPrevServer();
-    }
-
-    setNextLocation(null);
     setOpenModal(false);
+  };
+
+  const navigate = () => {
+    unblockRef.current();
+    history.push(nextLocation?.pathname);
   };
 
   const handleModalCancel = () => {
-    if (prevServerName) { // if a new central server was selected
-      setSelectedServer(nextServer);
-    } else { // otherwise, the navigation to the current page or leave from the page was pressed
-      setSelectedServer({});
-    }
-
+    setSelectedServer({});
     setOpenModal(false);
     setIsResetForm(true);
+    navigate();
   };
 
   useEffect(() => {
-    if (isPristine && nextLocation) {
-      setNextLocation(null);
-      history.push(nextLocation.pathname);
-    }
-  }, [isPristine, nextLocation]);
-
-  useEffect(() => {
-    const unblock = history.block(nextLocat => {
-      if (isPristine) { // if we navigate somewhere with empty additional fields
+    unblockRef.current = history.block(nextLocat => {
+      if (isPristine) {
         setSelectedServer({});
-      } else if (!isPristine) { // if we navigate somewhere with filled additional fields
+      } else {
         setOpenModal(true);
         setNextLocation(nextLocat);
-        setPrevServerName('');
       }
 
       return isPristine;
     });
 
-    return () => unblock();
+    return () => unblockRef.current();
   }, [isPristine]);
 
   return [

--- a/src/hooks/useCentralServers/useCentralServers.test.js
+++ b/src/hooks/useCentralServers/useCentralServers.test.js
@@ -20,9 +20,10 @@ const serverOptionsMock = [
 
 describe('useCentralServers hook', () => {
   let result;
+  let history;
 
   beforeEach(() => {
-    const history = createBrowserHistory();
+    history = createBrowserHistory();
 
     result = renderHook(() => useCentralServers(history, servers)).result;
   });
@@ -60,22 +61,6 @@ describe('useCentralServers hook', () => {
     expect(selectedServer).toMatchObject(servers[1]);
   });
 
-  it('should return openModal state as true', () => {
-    const changePristineState = result.current[5];
-
-    act(() => {
-      changePristineState(false);
-    });
-    const handleServerChange = result.all[1][7];
-
-    act(() => {
-      handleServerChange(servers[1].name);
-    });
-    const openModal = result.all[2][1];
-
-    expect(openModal).toBeTruthy();
-  });
-
   it('should return correct serverOptions', () => {
     const serverOptions = result.current[4];
 
@@ -93,26 +78,6 @@ describe('useCentralServers hook', () => {
 
       expect(openModal).toBeFalsy();
     });
-
-    it('should change selection option if prevServerName is true', () => {
-      const handleServerChange = result.current[7];
-
-      act(() => {
-        handleServerChange(servers[0].name);
-      });
-
-      const handleServerChangeAgain = result.all[1][7];
-
-      act(() => {
-        handleServerChangeAgain(servers[1].name);
-      });
-
-      const handleModalConfirm = result.all[2][8];
-
-      act(() => {
-        handleModalConfirm();
-      });
-    });
   });
 
   describe('handleModalCancel', () => {
@@ -122,6 +87,23 @@ describe('useCentralServers hook', () => {
       act(() => {
         handleModalCancel();
       });
+    });
+
+    it('should reset the selected server', () => {
+      const handleServerChange = result.current[7];
+
+      act(() => {
+        handleServerChange(servers[1].name);
+      });
+
+      const handleModalCancel = result.current[9];
+
+      act(() => {
+        handleModalCancel();
+      });
+      const selectedServer = result.current[0];
+
+      expect(selectedServer).toEqual({});
     });
 
     it('should close modal', () => {
@@ -134,6 +116,17 @@ describe('useCentralServers hook', () => {
       const isResetForm = result.current[2];
 
       expect(isResetForm).toBeTruthy();
+    });
+
+    it('should navigate to another location', () => {
+      const historyPushSpy = jest.spyOn(history, 'push');
+      const handleModalCancel = result.current[9];
+
+      act(() => {
+        handleModalCancel();
+      });
+      expect(historyPushSpy.mock.calls[0][0]).toBe();
+      historyPushSpy.mockClear();
     });
   });
 });

--- a/src/hooks/useCentralServers/useCentralServers.test.js
+++ b/src/hooks/useCentralServers/useCentralServers.test.js
@@ -133,19 +133,24 @@ describe('useCentralServers hook', () => {
   describe('unblock function', () => {
     it('should open a modal', async () => {
       const handleServerChange = result.current[7];
+
       act(() => { handleServerChange(servers[1].name); });
       const selectedServer1 = result.current[0];
+
       expect(selectedServer1).toEqual(servers[1]);
-      act(() => { history.push('/'); })
+      act(() => { history.push('/'); });
       const selectedServer2 = result.current[0];
+
       expect(selectedServer2).toEqual({});
     });
 
     it('should reset the selected server', () => {
       const changePristineState = result.current[5];
+
       act(() => { changePristineState(false); });
-      act(() => { history.push('/'); })
+      act(() => { history.push('/'); });
       const openModal = result.current[1];
+
       expect(openModal).toBeTruthy();
     });
   });

--- a/src/hooks/useCentralServers/useCentralServers.test.js
+++ b/src/hooks/useCentralServers/useCentralServers.test.js
@@ -129,4 +129,24 @@ describe('useCentralServers hook', () => {
       historyPushSpy.mockClear();
     });
   });
+
+  describe('unblock function', () => {
+    it('should open a modal', async () => {
+      const handleServerChange = result.current[7];
+      act(() => { handleServerChange(servers[1].name); });
+      const selectedServer1 = result.current[0];
+      expect(selectedServer1).toEqual(servers[1]);
+      act(() => { history.push('/'); })
+      const selectedServer2 = result.current[0];
+      expect(selectedServer2).toEqual({});
+    });
+
+    it('should reset the selected server', () => {
+      const changePristineState = result.current[5];
+      act(() => { changePristineState(false); });
+      act(() => { history.push('/'); })
+      const openModal = result.current[1];
+      expect(openModal).toBeTruthy();
+    });
+  });
 });

--- a/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/CentralServersConfigurationForm.js
+++ b/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/CentralServersConfigurationForm.js
@@ -83,13 +83,11 @@ const CentralConfigurationForm = ({
     section2: true,
   });
 
-  const loanTypeOptions = useMemo(() => (loanTypes
-    ? loanTypes.map(({ id, name }) => ({
-      label: name,
-      value: id,
-      id,
-    }))
-    : []), [loanTypes]);
+  const loanTypeOptions = useMemo(() => loanTypes.map(({ id, name }) => ({
+    label: name,
+    value: id,
+    id,
+  })), [loanTypes]);
 
   const changeLocalServerKeypair = (localServerKey, localServerSecret) => {
     form.change(LOCAL_SERVER_KEY, localServerKey);

--- a/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/CentralServersConfigurationForm.js
+++ b/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/CentralServersConfigurationForm.js
@@ -144,7 +144,6 @@ const CentralConfigurationForm = ({
       <Button
         data-testid="cancel-button"
         buttonStyle="default mega"
-        id="cancel-instance-edition"
         onClick={onCancel}
       >
         <FormattedMessage id="ui-inn-reach.settings.central-server-configuration.create-edit.button.cancel" />
@@ -154,7 +153,6 @@ const CentralConfigurationForm = ({
     const saveButton = (
       <Button
         data-testid="save-button"
-        id="clickable-save-instance"
         buttonStyle="primary mega"
         type="submit"
         disabled={invalid || !getIsCentralServerDataChanged() || pristine}
@@ -346,7 +344,6 @@ const CentralConfigurationForm = ({
                   data-testid="generate-keypair"
                   buttonStyle="default"
                   buttonClass={styles.generateKeypair}
-                  id="cancel-instance-edition"
                   onClick={generateKeyAndSecret}
                 >
                   <FormattedMessage id="ui-inn-reach.settings.central-server-configuration.create-edit.button.generateKeypair" />
@@ -378,9 +375,7 @@ export default stripesFinalForm({
   validate,
   subscription: {
     invalid: true,
-    error: true,
     dirtyFieldsSinceLastSubmit: true,
-    submitSucceeded: true,
     values: true,
   },
   initialValuesEqual: (a, b) => isEqual(a, b),

--- a/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/CentralServersConfigurationForm.test.js
+++ b/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/CentralServersConfigurationForm.test.js
@@ -49,23 +49,21 @@ const renderForm = ({
   onCancel,
   initialValues,
   onSubmit,
-  isCentralServerDataInvalid,
   showPrevLocalServerValue,
-  onMakeValidCentralServerData,
   onShowPreviousLocalServerValue,
+  onChangePristineState,
 }) => {
   return renderWithIntl(
     <MemoryRouter>
       <CentralServersConfigurationContext.Provider value={data}>
         <CentralServersConfigurationForm
           initialValues={initialValues}
-          isCentralServerDataInvalid={isCentralServerDataInvalid}
           showPrevLocalServerValue={showPrevLocalServerValue}
           onSaveLocalServerKeypair={jest.fn()}
           onCancel={onCancel}
           onSubmit={onSubmit}
-          onMakeValidCentralServerData={onMakeValidCentralServerData}
           onShowPreviousLocalServerValue={onShowPreviousLocalServerValue}
+          onChangePristineState={onChangePristineState}
         />
       </CentralServersConfigurationContext.Provider>
     </MemoryRouter>,
@@ -76,12 +74,13 @@ const renderForm = ({
 describe('CentralServerConfigurationForm component', () => {
   const handleCancel = jest.fn();
   const handleSubmit = jest.fn();
-  const onMakeValidCentralServerData = jest.fn();
   const onShowPreviousLocalServerValue = jest.fn();
+  const onChangePristineState = jest.fn();
   const commonProps = {
     initialValues: initValues,
     onSubmit: handleSubmit,
     onCancel: handleCancel,
+    onChangePristineState,
   };
 
   it('should display "edit" title', () => {
@@ -121,17 +120,6 @@ describe('CentralServerConfigurationForm component', () => {
     renderForm(commonProps);
     userEvent.click(screen.getByRole('button', { name: 'Close' }));
     expect(handleCancel).toBeCalled();
-  });
-
-  it('should cause onMakeValidCentralServerData callback', () => {
-    const { getByRole } = renderForm({
-      ...commonProps,
-      isCentralServerDataInvalid: true,
-      onMakeValidCentralServerData,
-    });
-
-    userEvent.type(getByRole('textbox', { name: 'Central server address' }), 'https://opentown-lib.edu/andromeda');
-    expect(onMakeValidCentralServerData).toHaveBeenCalled();
   });
 
   it('should show the original data of the local server', () => {

--- a/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateEditContainer.js
+++ b/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateEditContainer.js
@@ -1,5 +1,9 @@
-import React from 'react';
+import React, {
+  useEffect,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
@@ -21,23 +25,41 @@ export const DEFAULT_VALUES = {
 };
 
 const CentralServersConfigurationCreateEditContainer = ({
+  history,
   initialValues,
   showPrevLocalServerValue,
-  isCentralServerDataInvalid,
   onFormCancel,
   onSubmit,
   openModal,
   modalContent,
   onShowPreviousLocalServerValue,
-  onMakeValidCentralServerData,
   onModalCancel,
   onModalConfirm,
+  unblockRef,
+  onChangeModalState,
 }) => {
+  const [isPristine, setIsPristine] = useState(true);
   const intl = useIntl();
   const fieldsInitialValues = {
     ...DEFAULT_VALUES,
     ...initialValues,
   };
+
+  const changePristineState = (value) => {
+    setIsPristine(value);
+  };
+
+  useEffect(() => {
+    unblockRef.current = history.block(() => {
+      if (!isPristine) {
+        onChangeModalState(true);
+      }
+
+      return isPristine;
+    });
+
+    return () => unblockRef.current();
+  }, [isPristine]);
 
   return (
     <Paneset>
@@ -48,16 +70,17 @@ const CentralServersConfigurationCreateEditContainer = ({
       >
         <CentralServersConfigurationForm
           initialValues={fieldsInitialValues}
-          isCentralServerDataInvalid={isCentralServerDataInvalid}
           showPrevLocalServerValue={showPrevLocalServerValue}
           onShowPreviousLocalServerValue={onShowPreviousLocalServerValue}
-          onMakeValidCentralServerData={onMakeValidCentralServerData}
           onCancel={onFormCancel}
           onSubmit={onSubmit}
+          onChangePristineState={changePristineState}
         />
         <ConfirmationModal
           id="cancel-editing-confirmation"
           open={openModal}
+          buttonStyle={modalContent?.confirmLabel ? 'default' : 'primary'}
+          cancelButtonStyle={modalContent?.cancelLabel ? 'primary' : 'default'}
           heading={modalContent?.heading || <FormattedMessage id="ui-inn-reach.settings.central-server-configuration.create-edit.modal-heading.areYouSure" />}
           message={modalContent?.message || <FormattedMessage id="ui-inn-reach.settings.central-server-configuration.create-edit.modal-message.unsavedChanges" />}
           confirmLabel={modalContent?.confirmLabel || <FormattedMessage id="ui-inn-reach.settings.central-server-configuration.create-edit.modal-confirmLabel.keepEditing" />}
@@ -71,22 +94,22 @@ const CentralServersConfigurationCreateEditContainer = ({
 };
 
 CentralServersConfigurationCreateEditContainer.propTypes = {
+  history: ReactRouterPropTypes.history.isRequired,
   openModal: PropTypes.bool.isRequired,
+  unblockRef: PropTypes.object.isRequired,
   onFormCancel: PropTypes.func.isRequired,
   onModalCancel: PropTypes.func.isRequired,
   onModalConfirm: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   initialValues: PropTypes.object,
-  isCentralServerDataInvalid: PropTypes.bool,
   modalContent: PropTypes.object,
   showPrevLocalServerValue: PropTypes.bool,
-  onMakeValidCentralServerData: PropTypes.func,
+  onChangeModalState: PropTypes.func,
   onShowPreviousLocalServerValue: PropTypes.func,
 };
 
 CentralServersConfigurationCreateEditContainer.defaultProps = {
   initialValues: {},
-  isCentralServerDataInvalid: false,
   modalContent: {},
 };
 

--- a/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateEditContainer.js
+++ b/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateEditContainer.js
@@ -59,7 +59,7 @@ const CentralServersConfigurationCreateEditContainer = ({
     });
 
     return () => unblockRef.current();
-  }, [isPristine]);
+  }, [isPristine, history]);
 
   return (
     <Paneset>

--- a/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateEditContainer.test.js
+++ b/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateEditContainer.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
+import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -38,7 +39,6 @@ jest.mock('../../components/CentralServersConfiguration/CentralServersConfigurat
 
 const renderContainer = ({
   initialValues = undefined,
-  isCentralServerDataInvalid = false,
   showPrevLocalServerValue = false,
   onShowPreviousLocalServerValue = jest.fn(),
   onFormCancel = jest.fn(),
@@ -51,11 +51,12 @@ const renderContainer = ({
   return renderWithIntl(
     <MemoryRouter>
       <CentralServersConfigurationCreateEditContainer
+        history={createMemoryHistory()}
         initialValues={initialValues}
-        isCentralServerDataInvalid={isCentralServerDataInvalid}
         showPrevLocalServerValue={showPrevLocalServerValue}
         openModal={openModal}
         modalContent={modalContent}
+        unblockRef={{ current: jest.fn() }}
         onShowPreviousLocalServerValue={onShowPreviousLocalServerValue}
         onFormCancel={onFormCancel}
         onSubmit={onSubmit}
@@ -81,7 +82,6 @@ describe('CentralServersConfigurationCreateEditContainer', () => {
   it('should pass required props to CentralServersConfigurationForm', () => {
     const props = {
       initialValues: records,
-      isCentralServerDataInvalid: false,
       showPrevLocalServerValue: false,
       onShowPreviousLocalServerValue: jest.fn(),
       onFormCancel: jest.fn(),
@@ -91,7 +91,6 @@ describe('CentralServersConfigurationCreateEditContainer', () => {
     renderContainer(props);
 
     expect(CentralServersConfigurationForm.mock.calls[0][0].initialValues).toEqual(props.initialValues);
-    expect(CentralServersConfigurationForm.mock.calls[0][0].isCentralServerDataInvalid).toEqual(props.isCentralServerDataInvalid);
     expect(CentralServersConfigurationForm.mock.calls[0][0].showPrevLocalServerValue).toEqual(props.showPrevLocalServerValue);
     expect(CentralServersConfigurationForm.mock.calls[0][0].onShowPreviousLocalServerValue).toEqual(props.onShowPreviousLocalServerValue);
     expect(CentralServersConfigurationForm.mock.calls[0][0].onCancel).toEqual(props.onFormCancel);

--- a/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateEditContainer.test.js
+++ b/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateEditContainer.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { createMemoryHistory } from 'history';
+import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -38,6 +39,7 @@ jest.mock('../../components/CentralServersConfiguration/CentralServersConfigurat
 });
 
 const renderContainer = ({
+  history,
   initialValues = undefined,
   showPrevLocalServerValue = false,
   onShowPreviousLocalServerValue = jest.fn(),
@@ -47,11 +49,12 @@ const renderContainer = ({
   modalContent,
   onModalCancel = jest.fn(),
   onModalConfirm = jest.fn(),
+  onChangeModalState = jest.fn(),
 } = {}) => {
   return renderWithIntl(
     <MemoryRouter>
       <CentralServersConfigurationCreateEditContainer
-        history={createMemoryHistory()}
+        history={history}
         initialValues={initialValues}
         showPrevLocalServerValue={showPrevLocalServerValue}
         openModal={openModal}
@@ -62,6 +65,7 @@ const renderContainer = ({
         onSubmit={onSubmit}
         onModalCancel={onModalCancel}
         onModalConfirm={onModalConfirm}
+        onChangeModalState={onChangeModalState}
       />
     </MemoryRouter>,
     translationsProperties
@@ -69,18 +73,21 @@ const renderContainer = ({
 };
 
 describe('CentralServersConfigurationCreateEditContainer', () => {
+  const history = createMemoryHistory();
+
   beforeEach(() => {
     CentralServersConfigurationForm.mockClear();
   });
 
   it('should display CentralServersConfigurationForm', () => {
-    const { getByText } = renderContainer();
+    const { getByText } = renderContainer({ history });
 
     expect(getByText('CentralServersConfigurationForm')).toBeDefined();
   });
 
   it('should pass required props to CentralServersConfigurationForm', () => {
     const props = {
+      history,
       initialValues: records,
       showPrevLocalServerValue: false,
       onShowPreviousLocalServerValue: jest.fn(),
@@ -99,7 +106,10 @@ describe('CentralServersConfigurationCreateEditContainer', () => {
 
   describe('ConfirmationModal', () => {
     it('should be open when openModal prop is true', () => {
-      renderContainer({ openModal: true });
+      renderContainer({
+        history,
+        openModal: true,
+      });
       const modal = document.querySelector('#cancel-editing-confirmation');
 
       expect(modal).toBeDefined();
@@ -107,7 +117,10 @@ describe('CentralServersConfigurationCreateEditContainer', () => {
 
     describe('content', () => {
       it('should display default content', () => {
-        const { getByText } = renderContainer({ openModal: true });
+        const { getByText } = renderContainer({
+          history,
+          openModal: true,
+        });
 
         expect(getByText('Are you sure?')).toBeDefined();
         expect(getByText('There are unsaved changes')).toBeDefined();
@@ -117,6 +130,7 @@ describe('CentralServersConfigurationCreateEditContainer', () => {
 
       it('should display custom content', () => {
         const { getByText } = renderContainer({
+          history,
           openModal: true,
           modalContent: {
             heading: <FormattedMessage id="ui-inn-reach.settings.central-server-configuration.edit.modal-heading.updateLocalServerKeyConfirmation" />,
@@ -137,6 +151,7 @@ describe('CentralServersConfigurationCreateEditContainer', () => {
       const onModalConfirm = jest.fn();
 
       renderContainer({
+        history,
         openModal: true,
         onModalConfirm,
       });
@@ -151,6 +166,7 @@ describe('CentralServersConfigurationCreateEditContainer', () => {
       const onModalCancel = jest.fn();
 
       renderContainer({
+        history,
         openModal: true,
         onModalCancel,
       });
@@ -159,6 +175,20 @@ describe('CentralServersConfigurationCreateEditContainer', () => {
 
       userEvent.click(cancelButton);
       expect(onModalCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe('unblock function', () => {
+    it('should open a modal', async () => {
+      const onChangeModalState = jest.fn();
+
+      renderContainer({
+        history,
+        onChangeModalState,
+      });
+      act(() => { CentralServersConfigurationForm.mock.calls[0][0].onChangePristineState(false); });
+      history.push('/');
+      expect(onChangeModalState).toHaveBeenCalledWith(true);
     });
   });
 });

--- a/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateRoute.js
+++ b/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateRoute.js
@@ -44,7 +44,7 @@ const CentralServersConfigurationCreateRoute = ({
   };
 
   const navigate = () => {
-    unblockRef.current();
+    if (unblockRef.current) unblockRef.current();
     navigateToList();
   };
 

--- a/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateRoute.test.js
+++ b/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateRoute.test.js
@@ -148,6 +148,11 @@ describe('CentralServersConfigurationCreateRoute component', () => {
           },
         });
       });
+
+      it('should cause an error callout', () => {
+        act(() => CentralServersConfigurationCreateEditContainer.mock.calls[0][0].onSubmit(record));
+        expect(useCallout.mock.results[0].value()).toEqual('error');
+      });
     });
 
     describe('POST with error number not 400', () => {
@@ -202,6 +207,23 @@ describe('CentralServersConfigurationCreateRoute component', () => {
       });
 
       expect(CentralServersConfigurationCreateEditContainer.mock.calls[0][0]).toHaveProperty('openModal', false);
+    });
+  });
+
+  describe('handleModalCancel', () => {
+    it('should invoke the getCentralServerConfigurationListUrl', () => {
+      renderCreateRoute();
+      CentralServersConfigurationCreateEditContainer.mock.calls[0][0].onModalCancel();
+      expect(getCentralServerConfigurationListUrl).toHaveBeenCalled();
+      getCentralServerConfigurationListUrl.mockRestore();
+    });
+  });
+
+  describe('onChangeModalState', () => {
+    it('should change a modal state', () => {
+      renderCreateRoute();
+      act(() => { CentralServersConfigurationCreateEditContainer.mock.calls[0][0].onChangeModalState(true); });
+      expect(CentralServersConfigurationCreateEditContainer.mock.calls[1][0].openModal).toBeTruthy();
     });
   });
 });

--- a/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateRoute.test.js
+++ b/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateRoute.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import {
   act,
-  waitFor,
 } from '@testing-library/react';
 
 import {
@@ -90,12 +89,6 @@ describe('CentralServersConfigurationCreateRoute component', () => {
     expect(getByText('CentralServersConfigurationCreateEditContainer')).toBeDefined();
   });
 
-  it('should pass isCentralServerDataInvalid as false', async () => {
-    renderCreateRoute();
-    CentralServersConfigurationCreateEditContainer.mock.calls[0][0].onMakeValidCentralServerData();
-    expect(CentralServersConfigurationCreateEditContainer.mock.calls[0][0].isCentralServerDataInvalid).toEqual(false);
-  });
-
   describe('handleCreateRecord', () => {
     it('should be passed as submit prop', () => {
       renderCreateRoute();
@@ -138,12 +131,6 @@ describe('CentralServersConfigurationCreateRoute component', () => {
         expect(downloadJsonFile).not.toHaveBeenCalled();
         downloadJsonFile.mockRestore();
       });
-
-      it('should call navigation to the list page', async () => {
-        await CentralServersConfigurationCreateEditContainer.mock.calls[0][0].onSubmit(record);
-        expect(getCentralServerConfigurationListUrl).toHaveBeenCalled();
-        getCentralServerConfigurationListUrl.mockRestore();
-      });
     });
 
     describe('POST with error number 400', () => {
@@ -160,12 +147,6 @@ describe('CentralServersConfigurationCreateRoute component', () => {
             },
           },
         });
-      });
-
-      it('should pass isCentralServerDataInvalid as true', async () => {
-        await waitFor(() => CentralServersConfigurationCreateEditContainer.mock.calls[0][0].onSubmit(record));
-        expect(CentralServersConfigurationCreateEditContainer.mock.calls[1][0]).toHaveProperty('isCentralServerDataInvalid', true);
-        expect(useCallout.mock.results[0].value()).toEqual('error');
       });
     });
 
@@ -220,8 +201,7 @@ describe('CentralServersConfigurationCreateRoute component', () => {
         CentralServersConfigurationCreateEditContainer.mock.calls[0][0].onModalConfirm();
       });
 
-      expect(CentralServersConfigurationCreateEditContainer.mock.calls[1][0]).toHaveProperty('isCentralServerDataInvalid', true);
-      expect(CentralServersConfigurationCreateEditContainer.mock.calls[1][0]).toHaveProperty('openModal', false);
+      expect(CentralServersConfigurationCreateEditContainer.mock.calls[0][0]).toHaveProperty('openModal', false);
     });
   });
 });

--- a/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationEditRoute.test.js
+++ b/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationEditRoute.test.js
@@ -199,7 +199,6 @@ describe('CentralServersConfigurationEditRoute component', () => {
 
       expect(putMock).toHaveBeenCalled();
       expect(downloadJsonFile).not.toHaveBeenCalled();
-      expect(getCentralServerConfigurationViewUrl).toHaveBeenCalled();
 
       downloadJsonFile.mockRestore();
       getCentralServerConfigurationViewUrl.mockRestore();
@@ -269,11 +268,11 @@ describe('CentralServersConfigurationEditRoute component', () => {
         });
 
         act(() => {
-          CentralServersConfigurationCreateEditContainer.mock.calls[0][0].onSubmit(valuesWithChangedLocalServerKeyPair);
+          CentralServersConfigurationCreateEditContainer.mock.calls[1][0].onSubmit(valuesWithChangedLocalServerKeyPair);
         });
 
         act(() => {
-          CentralServersConfigurationCreateEditContainer.mock.calls[2][0].onModalConfirm();
+          CentralServersConfigurationCreateEditContainer.mock.calls[2][0].onModalCancel();
         });
       });
 
@@ -284,11 +283,6 @@ describe('CentralServersConfigurationEditRoute component', () => {
       it('should call downloadJsonFile with correct props', () => {
         expect(downloadJsonFile).toHaveBeenCalledWith(newLocalServerData, fileName);
         downloadJsonFile.mockRestore();
-      });
-
-      it('should call getCentralServerConfigurationViewUrl', () => {
-        expect(getCentralServerConfigurationViewUrl).toHaveBeenCalled();
-        getCentralServerConfigurationViewUrl.mockRestore();
       });
     });
   });
@@ -310,9 +304,8 @@ describe('CentralServersConfigurationEditRoute component', () => {
 
     it('should close modal', async () => {
       renderEditRoute();
-
-      await waitFor(() => CentralServersConfigurationCreateEditContainer.mock.calls[1][0].onModalCancel());
-      expect(CentralServersConfigurationCreateEditContainer.mock.calls[2][0]).toHaveProperty('openModal', false);
+      await waitFor(() => CentralServersConfigurationCreateEditContainer.mock.calls[1][0].onModalConfirm());
+      expect(CentralServersConfigurationCreateEditContainer.mock.calls[1][0]).toHaveProperty('openModal', false);
     });
   });
 


### PR DESCRIPTION
- removed the opening of a modal window when the central server is changed with dirty data
- fixed incorrect detection of central server data change in getIsCentralServerDataChanged function
- made a general modal window for creating and editing functionality