### PR TITLE
UIINREACH-48: Agency to FOLIO location - incorrect behavior after selecting the local server field placeholder

### DIFF
--- a/src/constants/agency-to-folio-locations.js
+++ b/src/constants/agency-to-folio-locations.js
@@ -2,6 +2,7 @@ export const CIRCULATION_MAPPINGS = 'Circulation mappings';
 export const AGENCY_TO_FOLIO_LOCATIONS_ROUTE = 'agency-to-folio-locations';
 
 export const AGENCY_TO_FOLIO_LOCATIONS_FIELDS = {
+  ID: 'id',
   CENTRAL_SERVER_ID: 'centralServerId',
   LIBRARY_ID: 'libraryId',
   LOCATION_ID: 'locationId',

--- a/src/hooks/useCentralServers/useCentralServers.js
+++ b/src/hooks/useCentralServers/useCentralServers.js
@@ -92,7 +92,7 @@ const useCentralServers = (history, servers) => {
     });
 
     return () => unblock();
-  }, [isPristine]);
+  }, [isPristine, history]);
 
   return [
     selectedServer,

--- a/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.js
+++ b/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.js
@@ -35,6 +35,7 @@ import {
 import {
   getFolioLocationOptions,
   getLocalServerOptions,
+  getSelectedOptionInfo,
   validateRequired,
 } from './utils';
 
@@ -95,9 +96,17 @@ const AgencyToFolioLocationsForm = ({
   const handleChangeServerLibrary = (libraryId) => {
     if (values[LIBRARY_ID] === libraryId) return;
 
-    const locOptions = getFolioLocationOptions(folioLocationsMap, libraryId);
+    const {
+      isNoValueOption,
+      selectedValue: selectedLibraryId,
+    } = getSelectedOptionInfo(libraryId);
 
-    form.change(LIBRARY_ID, libraryId);
+    const locOptions = isNoValueOption
+      ? []
+      : getFolioLocationOptions(folioLocationsMap, libraryId);
+
+    form.change(LIBRARY_ID, selectedLibraryId);
+    submitted.current = false;
     setServerLocationOptions(locOptions);
 
     if (agencyMappings[LIBRARY_ID] === libraryId) {
@@ -110,27 +119,46 @@ const AgencyToFolioLocationsForm = ({
   const handleChangeServerLocation = (locationId) => {
     if (values[LOCATION_ID] === locationId) return;
 
-    form.change(LOCATION_ID, locationId);
+    const { selectedValue: selectedLocationId } = getSelectedOptionInfo(locationId);
+
+    form.change(LOCATION_ID, selectedLocationId);
     submitted.current = false;
   };
 
   const handleChangeLocalServer = (localCode) => {
     if (values[LOCAL_CODE] === localCode) return;
 
-    onChangeLocalServer(localCode, values[LIBRARY_ID], values[LOCATION_ID]);
+    const {
+      isNoValueOption,
+      selectedValue: selectedLocalCode,
+    } = getSelectedOptionInfo(localCode);
+
+    onChangeLocalServer(localCode, values[LIBRARY_ID], values[LOCATION_ID], isNoValueOption);
     form.change(LOCAL_SERVER_LIBRARY_ID, undefined);
     form.change(LOCAL_SERVER_LOCATION_ID, undefined);
     form.change(AGENCY_CODE_MAPPINGS, undefined);
-    form.change(LOCAL_CODE, localCode);
+    form.change(LOCAL_CODE, selectedLocalCode);
   };
 
   const handleChangeLocalServerLibrary = (libraryId) => {
     if (values[LOCAL_SERVER_LIBRARY_ID] === libraryId) return;
 
-    const locOptions = getFolioLocationOptions(folioLocationsMap, libraryId);
-    const locServerData = getLocalServerData(agencyMappings, initialValues[LOCAL_CODE]);
+    const {
+      isNoValueOption,
+      selectedValue: selectedLocalServerLibrary,
+    } = getSelectedOptionInfo(libraryId);
 
-    form.change(LOCAL_SERVER_LIBRARY_ID, libraryId);
+    const locOptions = isNoValueOption
+      ? []
+      : getFolioLocationOptions(folioLocationsMap, libraryId);
+
+    let locServerData;
+
+    if (!isNoValueOption) {
+      locServerData = getLocalServerData(agencyMappings, initialValues[LOCAL_CODE]);
+    }
+
+    form.change(LOCAL_SERVER_LIBRARY_ID, selectedLocalServerLibrary);
     setLocalServerLocationOptions(locOptions);
 
     if (locServerData?.[LOCAL_SERVER_LIBRARY_ID] === libraryId) {
@@ -143,7 +171,9 @@ const AgencyToFolioLocationsForm = ({
   const handleChangeLocalServerLocation = (locationId) => {
     if (values[LOCAL_SERVER_LOCATION_ID] === locationId) return;
 
-    form.change(LOCAL_SERVER_LOCATION_ID, locationId);
+    const { selectedValue: selectedLocalServerLocation } = getSelectedOptionInfo(locationId);
+
+    form.change(LOCAL_SERVER_LOCATION_ID, selectedLocalServerLocation);
   };
 
   const handleSave = (event) => {
@@ -210,6 +240,7 @@ const AgencyToFolioLocationsForm = ({
                   id={LIBRARY_ID}
                   label={<FormattedMessage id="ui-inn-reach.settings.agency-to-folio-locations.field.folio-library" />}
                   dataOptions={libraryOptions}
+                  placeholder={formatMessage({ id: 'ui-inn-reach.settings.agency-to-folio-locations.placeholder.folio-library' })}
                   error={submitted.current ? meta.error : undefined}
                   onChange={handleChangeServerLibrary}
                 />
@@ -242,6 +273,7 @@ const AgencyToFolioLocationsForm = ({
             component={Selection}
             label={<FormattedMessage id="ui-inn-reach.settings.agency-to-folio-locations.field.local-server" />}
             dataOptions={localServerOptions}
+            placeholder={formatMessage({ id: 'ui-inn-reach.settings.agency-to-folio-locations.placeholder.local-server' })}
             onChange={handleChangeLocalServer}
           />
         }
@@ -253,6 +285,7 @@ const AgencyToFolioLocationsForm = ({
               component={Selection}
               label={<FormattedMessage id="ui-inn-reach.settings.agency-to-folio-locations.field.folio-library" />}
               dataOptions={libraryOptions}
+              placeholder={formatMessage({ id: 'ui-inn-reach.settings.agency-to-folio-locations.placeholder.folio-library' })}
               onChange={handleChangeLocalServerLibrary}
             />
             <Field

--- a/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.test.js
+++ b/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.test.js
@@ -6,6 +6,11 @@ import { screen } from '@testing-library/react';
 import { FormattedMessage } from 'react-intl';
 import { translationsProperties } from '../../../../../test/jest/helpers';
 import AgencyToFolioLocationsForm from './AgencyToFolioLocationsForm';
+import { AGENCY_TO_FOLIO_LOCATIONS_FIELDS } from '../../../../constants';
+
+const {
+  AGENCY_CODE_MAPPINGS,
+} = AGENCY_TO_FOLIO_LOCATIONS_FIELDS;
 
 const serverOptions = [
   {
@@ -220,6 +225,10 @@ describe('AgencyToFolioLocationsForm', () => {
         expect(screen.getByRole('button', { name })).toBeVisible();
       });
 
+      it('should add the tabular list', () => {
+        expect(screen.getByTestId(AGENCY_CODE_MAPPINGS)).toBeVisible();
+      });
+
       describe('handleChangeLocalServerLibrary', () => {
         const utils1 = jest.requireActual('./utils');
         const utils2 = jest.requireActual('../../../routes/AgencyToFolioLocations/utils');
@@ -243,6 +252,7 @@ describe('AgencyToFolioLocationsForm', () => {
 
   describe('handleLibraryChange in the tabular list', () => {
     it('should make the location field enabled', () => {
+      const name = 'FOLIO library & location Select location';
       const initialValuesMock = {
         localCode: '5dlpl',
         agencyCodeMappings: [{ agency: '5dlpl (Sierra Alpha)' }],
@@ -254,12 +264,10 @@ describe('AgencyToFolioLocationsForm', () => {
       document.getElementById('option-locationId-1-d428ca1d-f33b-4d4c-a160-d9f41c657bb7').click();
       document.getElementById('option-localCode-1-5dlpl').click();
       document.getElementById(`option-localServerLibraryId-1-${loclibs[0].id}`).click();
-      document.getElementById('agencyCodeMappings[0].libraryId').click();
-      document.getElementById(`option-agencyCodeMappings[0].libraryId-1-${loclibs[0].id}`).click();
-
-      const name = 'FOLIO location (default) ui-inn-reach.settings.agency-to-folio-locations.placeholder.folio-location';
-
-      expect(screen.getByRole('button', { name })).toBeVisible();
+      expect(screen.getByRole('button', { name })).toBeDisabled();
+      document.getElementById('agencyCodeMappings[0].libraryId-0').click();
+      document.getElementById(`option-agencyCodeMappings[0].libraryId-0-1-${loclibs[0].id}`).click();
+      expect(screen.getByRole('button', { name })).toBeEnabled();
     });
   });
 });

--- a/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/components/TabularList/TabularList.js
+++ b/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/components/TabularList/TabularList.js
@@ -12,6 +12,7 @@ import {
 
 import {
   AGENCY_TO_FOLIO_LOCATIONS_FIELDS,
+  NO_VALUE_OPTION_VALUE,
 } from '../../../../../../constants';
 import {
   getFolioLocationOptions,
@@ -34,6 +35,7 @@ const TabularList = ({
   const { formatMessage } = useIntl();
 
   const handleLibraryChange = (libId, index, fields) => {
+    const isNoValueOption = libId === NO_VALUE_OPTION_VALUE;
     const {
       id,
       libraryId,
@@ -42,21 +44,24 @@ const TabularList = ({
 
     const rowData = {
       [AGENCY]: fields.value[index][AGENCY],
-      [LIBRARY_ID]: libId,
     };
 
+    if (!isNoValueOption) {
+      rowData[LIBRARY_ID] = libId;
+    }
     if (libraryId === libId) {
       rowData[LOCATION_ID] = locationId;
     }
-    if (id) {
-      rowData.id = id;
-    }
+    if (id) rowData.id = id;
 
     fields.update(index, rowData);
   };
 
   return (
-    <Col sm={12}>
+    <Col
+      sm={12}
+      data-testid={AGENCY_CODE_MAPPINGS}
+    >
       <Row>
         <Col
           className={css.tabularHeaderCol}
@@ -89,6 +94,7 @@ const TabularList = ({
                 className={css.tabularCol}
               >
                 <Field
+                  id={`${name}.${AGENCY}${index}`}
                   name={`${name}.${AGENCY}`}
                   component={({ input }) => input.value}
                 />
@@ -100,20 +106,21 @@ const TabularList = ({
                 <div className={css.topFieldWrapper}>
                   <Field
                     marginBottom0
-                    id={`${name}.${LIBRARY_ID}`}
+                    id={`${name}.${LIBRARY_ID}-${index}`}
                     name={`${name}.${LIBRARY_ID}`}
-                    aria-label={formatMessage({ id: 'ui-inn-reach.settings.agency-to-folio-locations.placeholder.folio-library' })}
+                    aria-label={formatMessage({ id: 'ui-inn-reach.settings.agency-to-folio-locations.field.folio-library-and-location' })}
                     component={Selection}
                     dataOptions={librariesOptions}
+                    placeholder={formatMessage({ id: 'ui-inn-reach.settings.agency-to-folio-locations.placeholder.folio-library' })}
                     onChange={libId => handleLibraryChange(libId, index, fields)}
                   />
                 </div>
                 <Field
                   marginBottom0
-                  id={`${name}.${LOCATION_ID}`}
+                  id={`${name}.${LOCATION_ID}-${index}`}
                   disabled={!libraryId}
                   name={`${name}.${LOCATION_ID}`}
-                  aria-label={formatMessage({ id: 'ui-inn-reach.settings.agency-to-folio-locations.placeholder.folio-location' })}
+                  aria-label={formatMessage({ id: 'ui-inn-reach.settings.agency-to-folio-locations.field.folio-library-and-location' })}
                   component={Selection}
                   dataOptions={locationOptions}
                   placeholder={formatMessage({ id: 'ui-inn-reach.settings.agency-to-folio-locations.placeholder.folio-location' })}

--- a/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/components/TabularList/TabularList.js
+++ b/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/components/TabularList/TabularList.js
@@ -21,6 +21,7 @@ import {
 import css from './TabularList.css';
 
 const {
+  ID,
   AGENCY,
   LIBRARY_ID,
   LOCATION_ID,
@@ -52,7 +53,7 @@ const TabularList = ({
     if (libraryId === libId) {
       rowData[LOCATION_ID] = locationId;
     }
-    if (id) rowData.id = id;
+    if (id) rowData[ID] = id;
 
     fields.update(index, rowData);
   };

--- a/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/utils.js
+++ b/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/utils.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+import { NO_VALUE_OPTION_VALUE } from '../../../../constants';
 
 export const validateRequired = (value) => {
   return value
@@ -8,12 +9,10 @@ export const validateRequired = (value) => {
 };
 
 export const getFolioLocationOptions = (folioLocationsMap, libraryId) => {
-  if (!libraryId) return [];
-
   const locationsBySelectedLib = folioLocationsMap.get(libraryId);
   const noValueOption = {
     label: <FormattedMessage id="ui-inn-reach.settings.agency-to-folio-locations.placeholder.folio-location" />,
-    value: '',
+    value: NO_VALUE_OPTION_VALUE,
   };
 
   return locationsBySelectedLib.reduce((accum, { id, name, code }) => {
@@ -38,7 +37,7 @@ export const getLocalServerOptions = ({ localServerList }) => {
 
   const noValueOption = {
     label: <FormattedMessage id="ui-inn-reach.settings.agency-to-folio-locations.placeholder.local-server" />,
-    value: '',
+    value: NO_VALUE_OPTION_VALUE,
   };
 
   return localServerList.reduce((accum, { localCode, description }) => {
@@ -55,4 +54,14 @@ export const getLocalServerOptions = ({ localServerList }) => {
 
     return accum;
   }, []);
+};
+
+export const getSelectedOptionInfo = (selectedOptionValue) => {
+  const isNoValueOption = selectedOptionValue === NO_VALUE_OPTION_VALUE;
+  const selectedValue = isNoValueOption ? undefined : selectedOptionValue;
+
+  return {
+    isNoValueOption,
+    selectedValue,
+  };
 };

--- a/src/settings/components/ContributionOptions/ContributionOptionsForm/ContributionOptionsForm.test.js
+++ b/src/settings/components/ContributionOptions/ContributionOptionsForm/ContributionOptionsForm.test.js
@@ -65,6 +65,7 @@ const renderContributionOptionsForm = ({
   selectedServer = selectedServerMock,
   isContributionOptionsPending = false,
   isPristine = true,
+  isServersPending = false,
   initialValues = DEFAULT_VALUES,
   isResetForm = false,
   onChangeFormResetState,
@@ -79,6 +80,7 @@ const renderContributionOptionsForm = ({
         selectedServer={selectedServer}
         isContributionOptionsPending={isContributionOptionsPending}
         isPristine={isPristine}
+        isServersPending={isServersPending}
         serverOptions={serverOptions}
         materialTypes={materialTypes}
         loanTypes={loanTypes}

--- a/src/settings/components/MaterialType/MaterialTypeForm/MaterialTypeForm.test.js
+++ b/src/settings/components/MaterialType/MaterialTypeForm/MaterialTypeForm.test.js
@@ -42,6 +42,8 @@ const renderMappingTypeForm = ({
   selectedServer = selectedServerMock,
   isMaterialTypeMappingsPending = false,
   isPristine = true,
+  isPending = false,
+  isServersPending = false,
   initialValues = {},
   isResetForm = false,
   onChangeFormResetState,
@@ -55,7 +57,9 @@ const renderMappingTypeForm = ({
       <MaterialTypeForm
         selectedServer={selectedServer}
         isMaterialTypeMappingsPending={isMaterialTypeMappingsPending}
+        isPending={isPending}
         isPristine={isPristine}
+        isServersPending={isServersPending}
         serverOptions={serverOptions}
         innReachItemTypeOptions={centralItemTypes}
         initialValues={initialValues}

--- a/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.js
+++ b/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.js
@@ -103,12 +103,7 @@ const AgencyToFolioLocationsCreateEditRoute = ({
 
     mutator.localServers.GET()
       .then(response => setLocalServers(response))
-      .catch(() => {
-        showCallout({
-          type: CALLOUT_ERROR_TYPE,
-          message: <FormattedMessage id="ui-inn-reach.settings.agency-to-folio-locations.callout.connection-problem.get" />,
-        });
-      })
+      .catch(() => null)
       .finally(() => setIsLocalServersPending(false));
   };
 

--- a/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.js
+++ b/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.js
@@ -145,11 +145,20 @@ const AgencyToFolioLocationsCreateEditRoute = ({
     setLibraryOptions(libOptions);
   };
 
-  const addLocalInitialValues = (localCode, libraryId, locationId) => {
-    const locServerData = getLocalServerData(agencyMappings, localCode);
+  const addLocalInitialValues = (localCode, libraryId, locationId, isNoValueOption) => {
     const { localServerList } = localServers;
+    let locServerData;
 
-    if (locServerData) {
+    if (!isNoValueOption) {
+      locServerData = getLocalServerData(agencyMappings, localCode);
+    }
+
+    if (isNoValueOption) {
+      setInitialValues({
+        libraryId,
+        locationId,
+      });
+    } else if (locServerData) {
       setInitialValues({
         libraryId,
         locationId,

--- a/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.test.js
+++ b/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.test.js
@@ -13,6 +13,7 @@ import { FormattedMessage } from 'react-intl';
 import { translationsProperties } from '../../../../test/jest/helpers';
 import AgencyToFolioLocationsCreateEditRoute from './AgencyToFolioLocationsCreateEditRoute';
 import AgencyToFolioLocationsForm from '../../components/AgencyToFolioLocations/AgencyToFolioLocationsForm';
+import { NO_VALUE_OPTION_VALUE } from '../../../constants';
 
 jest.mock('../../components/AgencyToFolioLocations/AgencyToFolioLocationsForm', () => {
   return jest.fn(() => <div>AgencyToFolioLocationsForm</div>);
@@ -348,6 +349,22 @@ describe('AgencyToFolioLocationsCreateEditRoute component', () => {
   });
 
   describe('addLocalInitialValues function', () => {
+    it('should add the server libraryId and locationId to the initialValues', () => {
+      renderAgencyToFolioLocationsCreateEditRoute({ history });
+      act(() => {
+        AgencyToFolioLocationsForm.mock.calls[1][0].onChangeLocalServer(
+          NO_VALUE_OPTION_VALUE,
+          loclibs[0].id,
+          locations[0].id,
+          true,
+        );
+      });
+      expect(AgencyToFolioLocationsForm.mock.calls[2][0].initialValues).toEqual({
+        libraryId: loclibs[0].id,
+        locationId: locations[0].id,
+      });
+    });
+
     it('should add to initialValues all data of the tabular list', async () => {
       renderAgencyToFolioLocationsCreateEditRoute({ history });
       await act(async () => { await AgencyToFolioLocationsForm.mock.calls[1][0].onChangeServer(servers[0].id); });

--- a/src/settings/routes/AgencyToFolioLocations/utils.js
+++ b/src/settings/routes/AgencyToFolioLocations/utils.js
@@ -5,6 +5,7 @@ import {
 import { FormattedMessage } from 'react-intl';
 import {
   AGENCY_TO_FOLIO_LOCATIONS_FIELDS,
+  NO_VALUE_OPTION_VALUE,
 } from '../../../constants';
 
 const {
@@ -51,7 +52,7 @@ export const getFolioLibraryOptions = (folioLibraries, campuses, institutions) =
   const mapByInstitutionId = getMapByInstitutionId(campuses, mapByCampusId);
   const noValueOption = {
     label: <FormattedMessage id="ui-inn-reach.settings.agency-to-folio-locations.placeholder.folio-library" />,
-    value: '',
+    value: NO_VALUE_OPTION_VALUE,
   };
 
   institutions.forEach(({ id, code: institutionCode }) => {

--- a/src/settings/routes/ContributionOptionsRoute/ContributionOptionsCreateEditRoute.test.js
+++ b/src/settings/routes/ContributionOptionsRoute/ContributionOptionsCreateEditRoute.test.js
@@ -4,7 +4,7 @@ import {
   omit,
 } from 'lodash';
 import { createMemoryHistory } from 'history';
-import { waitFor, screen } from '@testing-library/react';
+import { waitFor, screen, act } from '@testing-library/react';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 import { ConfirmationModal } from '@folio/stripes-components';
@@ -251,7 +251,7 @@ describe('ContributionOptionsCreateEditRoute component', () => {
           mutator: newMutator,
         });
       });
-      ContributionOptionsForm.mock.calls[3][0].onSubmit(record);
+      await act(async () => { await ContributionOptionsForm.mock.calls[3][0].onSubmit(record); });
       expect(postMock).toHaveBeenCalledWith(finalRecord);
     });
 
@@ -266,7 +266,7 @@ describe('ContributionOptionsCreateEditRoute component', () => {
           mutator: newMutator,
         });
       });
-      ContributionOptionsForm.mock.calls[3][0].onSubmit(record);
+      await act(async () => { await ContributionOptionsForm.mock.calls[3][0].onSubmit(record); });
       expect(putMock).toHaveBeenCalledWith(finalRecord);
     });
   });


### PR DESCRIPTION
- fixed behavior after selecting the default option
- removed displaying of an empty value in the 'values' prop
- deleted error callout for local servers
- removed test errors