### PR TITLE
UIINREACH-56: INN-Reach Settings: For Settings that Require Latest Information from Central Server, Indicate Central Server Configuration Errors and Prevent Editing

### DIFF
--- a/src/constants/base.js
+++ b/src/constants/base.js
@@ -9,6 +9,7 @@ export const FILL_PANE_WIDTH = 'fill';
 export const METADATA = 'metadata';
 
 export const CALLOUT_ERROR_TYPE = 'error';
+export const BANNER_ERROR_TYPE = 'error';
 
 export const ICONS = {
   ADD: 'plus-sign',

--- a/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.js
+++ b/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.js
@@ -68,7 +68,7 @@ const AgencyToFolioLocationsForm = ({
   form,
   serverLocationOptions,
   localServerLocationOptions,
-  bannerMessage,
+  localServersFailed,
   onChangeServer,
   onChangeLocalServer,
   onChangePristineState,
@@ -88,6 +88,7 @@ const AgencyToFolioLocationsForm = ({
   const isServerFieldsChanged = isLibraryChanged || isLocationChanged;
   const isLocalServerFieldsChanged = values[LOCAL_CODE] &&
     (isLocalServerLibraryChanged || isLocalServerLocationChanged || isAgencyCodeMappingsChanged);
+  const isValidCentralServerConfig = ((values[LOCATION_ID] && !isLocalServersPending) || values[LOCAL_CODE]) && !localServersFailed;
 
   const isPristine = !(
     isLibraryChanged ||
@@ -279,11 +280,11 @@ const AgencyToFolioLocationsForm = ({
         }
         <MessageBanner
           type={BANNER_ERROR_TYPE}
-          show={!!bannerMessage}
+          show={localServersFailed}
         >
-          {bannerMessage}
+          <FormattedMessage id="ui-inn-reach.banner.local-servers" />
         </MessageBanner>
-        {((values[LOCATION_ID] && !isLocalServersPending) || values[LOCAL_CODE]) && !bannerMessage &&
+        {isValidCentralServerConfig &&
           <Field
             id={LOCAL_CODE}
             name={LOCAL_CODE}
@@ -345,7 +346,6 @@ AgencyToFolioLocationsForm.propTypes = {
       })),
     })),
   }).isRequired,
-  bannerMessage: PropTypes.string.isRequired,
   form: PropTypes.object.isRequired,
   formatMessage: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
@@ -367,6 +367,7 @@ AgencyToFolioLocationsForm.propTypes = {
     reason: PropTypes.string,
     status: PropTypes.string,
   }).isRequired,
+  localServersFailed: PropTypes.bool.isRequired,
   selectedServer: PropTypes.object.isRequired,
   serverLocationOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
   serverOptions: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.js
+++ b/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.js
@@ -19,10 +19,12 @@ import {
   Pane,
   PaneFooter,
   Selection,
+  MessageBanner,
 } from '@folio/stripes-components';
 
 import {
   AGENCY_TO_FOLIO_LOCATIONS_FIELDS,
+  BANNER_ERROR_TYPE,
   CENTRAL_SERVER_ID,
   DEFAULT_PANE_WIDTH,
 } from '../../../../constants';
@@ -66,6 +68,7 @@ const AgencyToFolioLocationsForm = ({
   form,
   serverLocationOptions,
   localServerLocationOptions,
+  bannerMessage,
   onChangeServer,
   onChangeLocalServer,
   onChangePristineState,
@@ -274,7 +277,13 @@ const AgencyToFolioLocationsForm = ({
             </Field>
           </>
         }
-        {((values[LOCATION_ID] && !isLocalServersPending) || values[LOCAL_CODE]) &&
+        <MessageBanner
+          type={BANNER_ERROR_TYPE}
+          show={!!bannerMessage}
+        >
+          {bannerMessage}
+        </MessageBanner>
+        {((values[LOCATION_ID] && !isLocalServersPending) || values[LOCAL_CODE]) && !bannerMessage &&
           <Field
             id={LOCAL_CODE}
             name={LOCAL_CODE}
@@ -336,6 +345,7 @@ AgencyToFolioLocationsForm.propTypes = {
       })),
     })),
   }).isRequired,
+  bannerMessage: PropTypes.string.isRequired,
   form: PropTypes.object.isRequired,
   formatMessage: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,

--- a/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.test.js
+++ b/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.test.js
@@ -148,6 +148,7 @@ const renderAgencyToFolioLocationsForm = ({
   values = {},
   form,
   agencyMappings = {},
+  bannerMessage = '',
   onChangeServer,
   onChangeLocalServer,
   isLocalServersPending = false,
@@ -173,6 +174,7 @@ const renderAgencyToFolioLocationsForm = ({
         form={form}
         serverLocationOptions={serverLocationOptions}
         localServerLocationOptions={localServerLocationOptions}
+        bannerMessage={bannerMessage}
         onSubmit={handleSubmit}
         onChangeServer={onChangeServer}
         onChangeLocalServer={onChangeLocalServer}
@@ -313,6 +315,28 @@ describe('AgencyToFolioLocationsForm', () => {
       document.getElementById('agencyCodeMappings[0].libraryId-0').click();
       document.getElementById(`option-agencyCodeMappings[0].libraryId-0-1-${loclibs[0].id}`).click();
       expect(screen.getByRole('button', { name })).toBeEnabled();
+    });
+  });
+
+  describe('banner', () => {
+    it('should be visible', () => {
+      const bannerMessage = 'some kind of error message';
+      const { getByText } = renderAgencyToFolioLocationsForm({
+        ...commonProps,
+        bannerMessage,
+      });
+
+      expect(getByText(bannerMessage)).toBeVisible();
+    });
+
+    it('should be invisible', () => {
+      renderAgencyToFolioLocationsForm({
+        ...commonProps,
+        bannerMessage: '',
+      });
+      const banner = document.querySelector('[data-test-message-banner]');
+
+      expect(banner).toBeFalsy();
     });
   });
 });

--- a/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.test.js
+++ b/src/settings/components/AgencyToFolioLocations/AgencyToFolioLocationsForm/AgencyToFolioLocationsForm.test.js
@@ -148,7 +148,7 @@ const renderAgencyToFolioLocationsForm = ({
   values = {},
   form,
   agencyMappings = {},
-  bannerMessage = '',
+  localServersFailed = false,
   onChangeServer,
   onChangeLocalServer,
   isLocalServersPending = false,
@@ -174,7 +174,7 @@ const renderAgencyToFolioLocationsForm = ({
         form={form}
         serverLocationOptions={serverLocationOptions}
         localServerLocationOptions={localServerLocationOptions}
-        bannerMessage={bannerMessage}
+        localServersFailed={localServersFailed}
         onSubmit={handleSubmit}
         onChangeServer={onChangeServer}
         onChangeLocalServer={onChangeLocalServer}
@@ -320,19 +320,19 @@ describe('AgencyToFolioLocationsForm', () => {
 
   describe('banner', () => {
     it('should be visible', () => {
-      const bannerMessage = 'some kind of error message';
-      const { getByText } = renderAgencyToFolioLocationsForm({
+      renderAgencyToFolioLocationsForm({
         ...commonProps,
-        bannerMessage,
+        localServersFailed: true,
       });
+      const banner = document.querySelector('[data-test-message-banner]');
 
-      expect(getByText(bannerMessage)).toBeVisible();
+      expect(banner).toBeVisible();
     });
 
     it('should be invisible', () => {
       renderAgencyToFolioLocationsForm({
         ...commonProps,
-        bannerMessage: '',
+        localServersFailed: false,
       });
       const banner = document.querySelector('[data-test-message-banner]');
 

--- a/src/settings/components/MaterialType/MaterialTypeForm/MaterialTypeForm.js
+++ b/src/settings/components/MaterialType/MaterialTypeForm/MaterialTypeForm.js
@@ -39,7 +39,7 @@ const MaterialTypeForm = ({
   handleSubmit,
   values,
   form,
-  bannerMessage,
+  innReachItemTypesFailed,
   onChangePristineState,
   onChangeFormResetState,
   onChangeServer,
@@ -97,11 +97,11 @@ const MaterialTypeForm = ({
       {isPending && <Loading />}
       <MessageBanner
         type={BANNER_ERROR_TYPE}
-        show={!!bannerMessage}
+        show={innReachItemTypesFailed}
       >
-        {bannerMessage}
+        <FormattedMessage id="ui-inn-reach.banner.item-types" />
       </MessageBanner>
-      {selectedServer.id && !isPending && !bannerMessage &&
+      {selectedServer.id && !isPending && !innReachItemTypesFailed &&
         <form>
           <MaterialTypeMappingList
             innReachItemTypeOptions={innReachItemTypeOptions}
@@ -113,11 +113,11 @@ const MaterialTypeForm = ({
 };
 
 MaterialTypeForm.propTypes = {
-  bannerMessage: PropTypes.string.isRequired,
   form: PropTypes.object.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   initialValues: PropTypes.object.isRequired,
   innReachItemTypeOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  innReachItemTypesFailed: PropTypes.bool.isRequired,
   invalid: PropTypes.bool.isRequired,
   isPending: PropTypes.bool.isRequired,
   isPristine: PropTypes.bool.isRequired,

--- a/src/settings/components/MaterialType/MaterialTypeForm/MaterialTypeForm.js
+++ b/src/settings/components/MaterialType/MaterialTypeForm/MaterialTypeForm.js
@@ -15,12 +15,14 @@ import {
   Row,
   Selection,
   Loading,
+  MessageBanner,
 } from '@folio/stripes-components';
 import stripesFinalForm from '@folio/stripes/final-form';
 
 import {
   DEFAULT_PANE_WIDTH,
   CENTRAL_SERVER_ID,
+  BANNER_ERROR_TYPE,
 } from '../../../../constants';
 import { MaterialTypeMappingList } from '../components';
 
@@ -37,6 +39,7 @@ const MaterialTypeForm = ({
   handleSubmit,
   values,
   form,
+  bannerMessage,
   onChangePristineState,
   onChangeFormResetState,
   onChangeServer,
@@ -92,7 +95,13 @@ const MaterialTypeForm = ({
         </Col>
       </Row>
       {isPending && <Loading />}
-      {selectedServer.id && !isPending &&
+      <MessageBanner
+        type={BANNER_ERROR_TYPE}
+        show={!!bannerMessage}
+      >
+        {bannerMessage}
+      </MessageBanner>
+      {selectedServer.id && !isPending && !bannerMessage &&
         <form>
           <MaterialTypeMappingList
             innReachItemTypeOptions={innReachItemTypeOptions}
@@ -104,6 +113,7 @@ const MaterialTypeForm = ({
 };
 
 MaterialTypeForm.propTypes = {
+  bannerMessage: PropTypes.string.isRequired,
   form: PropTypes.object.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   initialValues: PropTypes.object.isRequired,

--- a/src/settings/components/MaterialType/MaterialTypeForm/MaterialTypeForm.test.js
+++ b/src/settings/components/MaterialType/MaterialTypeForm/MaterialTypeForm.test.js
@@ -47,7 +47,7 @@ const renderMappingTypeForm = ({
   initialValues = {},
   invalid = false,
   isResetForm = false,
-  bannerMessage = '',
+  innReachItemTypesFailed = false,
   onChangeFormResetState,
   onChangePristineState,
   history = createMemoryHistory(),
@@ -67,7 +67,7 @@ const renderMappingTypeForm = ({
         innReachItemTypeOptions={centralItemTypes}
         initialValues={initialValues}
         isResetForm={isResetForm}
-        bannerMessage={bannerMessage}
+        innReachItemTypesFailed={innReachItemTypesFailed}
         onChangeFormResetState={onChangeFormResetState}
         onChangePristineState={onChangePristineState}
         onSubmit={handleSubmit}
@@ -116,19 +116,19 @@ describe('MaterialTypeForm', () => {
 
   describe('banner', () => {
     it('should be visible', () => {
-      const bannerMessage = 'some kind of error message';
-      const { getByText } = renderMappingTypeForm({
+      renderMappingTypeForm({
         ...commonProps,
-        bannerMessage,
+        innReachItemTypesFailed: true,
       });
+      const banner = document.querySelector('[data-test-message-banner]');
 
-      expect(getByText(bannerMessage)).toBeVisible();
+      expect(banner).toBeVisible();
     });
 
     it('should be invisible', () => {
       renderMappingTypeForm({
         ...commonProps,
-        bannerMessage: '',
+        innReachItemTypesFailed: false,
       });
       const banner = document.querySelector('[data-test-message-banner]');
 

--- a/src/settings/components/MaterialType/MaterialTypeForm/MaterialTypeForm.test.js
+++ b/src/settings/components/MaterialType/MaterialTypeForm/MaterialTypeForm.test.js
@@ -47,6 +47,7 @@ const renderMappingTypeForm = ({
   initialValues = {},
   invalid = false,
   isResetForm = false,
+  bannerMessage = '',
   onChangeFormResetState,
   onChangePristineState,
   history = createMemoryHistory(),
@@ -66,6 +67,7 @@ const renderMappingTypeForm = ({
         innReachItemTypeOptions={centralItemTypes}
         initialValues={initialValues}
         isResetForm={isResetForm}
+        bannerMessage={bannerMessage}
         onChangeFormResetState={onChangeFormResetState}
         onChangePristineState={onChangePristineState}
         onSubmit={handleSubmit}
@@ -110,5 +112,27 @@ describe('MaterialTypeForm', () => {
       isResetForm: true,
     });
     expect(onChangeFormResetState).toHaveBeenCalledWith(false);
+  });
+
+  describe('banner', () => {
+    it('should be visible', () => {
+      const bannerMessage = 'some kind of error message';
+      const { getByText } = renderMappingTypeForm({
+        ...commonProps,
+        bannerMessage,
+      });
+
+      expect(getByText(bannerMessage)).toBeVisible();
+    });
+
+    it('should be invisible', () => {
+      renderMappingTypeForm({
+        ...commonProps,
+        bannerMessage: '',
+      });
+      const banner = document.querySelector('[data-test-message-banner]');
+
+      expect(banner).toBeFalsy();
+    });
   });
 });

--- a/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.js
+++ b/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.js
@@ -97,7 +97,7 @@ const AgencyToFolioLocationsCreateEditRoute = ({
   const [nextLocation, setNextLocation] = useState(null);
   const [serverLocationOptions, setServerLocationOptions] = useState([]);
   const [localServerLocationOptions, setLocalServerLocationOptions] = useState([]);
-  const [bannerMessage, setBannerMessage] = useState('');
+  const [localServersFailed, setLocalServersFailed] = useState(false);
 
   const serverOptions = useMemo(() => getCentralServerOptions(servers), [servers]);
 
@@ -113,9 +113,7 @@ const AgencyToFolioLocationsCreateEditRoute = ({
     mutator.localServers.GET()
       .then(response => setLocalServers(response))
       .catch(() => {
-        const message = formatMessage({ id: 'ui-inn-reach.banner.local-servers' });
-
-        setBannerMessage(message);
+        setLocalServersFailed(true);
         setLocalServers({});
       })
       .finally(() => setIsLocalServersPending(false));
@@ -127,7 +125,7 @@ const AgencyToFolioLocationsCreateEditRoute = ({
     setIsResetForm(true);
     setServerLocationOptions([]);
     setLocalServerLocationOptions([]);
-    setBannerMessage('');
+    setLocalServersFailed(false);
   };
 
   const resetCentralServer = () => {
@@ -337,7 +335,7 @@ const AgencyToFolioLocationsCreateEditRoute = ({
         isResetForm={isResetForm}
         serverLocationOptions={serverLocationOptions}
         localServerLocationOptions={localServerLocationOptions}
-        bannerMessage={bannerMessage}
+        localServersFailed={localServersFailed}
         onSubmit={handleSubmit}
         onChangeServer={changeServer}
         onChangeLocalServer={addLocalInitialValues}

--- a/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.js
+++ b/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.js
@@ -97,6 +97,7 @@ const AgencyToFolioLocationsCreateEditRoute = ({
   const [nextLocation, setNextLocation] = useState(null);
   const [serverLocationOptions, setServerLocationOptions] = useState([]);
   const [localServerLocationOptions, setLocalServerLocationOptions] = useState([]);
+  const [bannerMessage, setBannerMessage] = useState('');
 
   const serverOptions = useMemo(() => getCentralServerOptions(servers), [servers]);
 
@@ -111,7 +112,12 @@ const AgencyToFolioLocationsCreateEditRoute = ({
 
     mutator.localServers.GET()
       .then(response => setLocalServers(response))
-      .catch(() => setLocalServers({}))
+      .catch(() => {
+        const message = formatMessage({ id: 'ui-inn-reach.banner.local-servers' });
+
+        setBannerMessage(message);
+        setLocalServers({});
+      })
       .finally(() => setIsLocalServersPending(false));
   };
 
@@ -121,6 +127,7 @@ const AgencyToFolioLocationsCreateEditRoute = ({
     setIsResetForm(true);
     setServerLocationOptions([]);
     setLocalServerLocationOptions([]);
+    setBannerMessage('');
   };
 
   const resetCentralServer = () => {
@@ -330,6 +337,7 @@ const AgencyToFolioLocationsCreateEditRoute = ({
         isResetForm={isResetForm}
         serverLocationOptions={serverLocationOptions}
         localServerLocationOptions={localServerLocationOptions}
+        bannerMessage={bannerMessage}
         onSubmit={handleSubmit}
         onChangeServer={changeServer}
         onChangeLocalServer={addLocalInitialValues}

--- a/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.test.js
+++ b/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.test.js
@@ -430,4 +430,24 @@ describe('AgencyToFolioLocationsCreateEditRoute component', () => {
       expect(mutatorMock.agencyMappings.PUT).toHaveBeenCalledWith(finalRecord);
     });
   });
+
+  describe('banner', () => {
+    it('should be visible', async () => {
+      const newMutatorMock = cloneDeep(mutatorMock);
+
+      newMutatorMock.localServers.GET = jest.fn(() => Promise.reject());
+      renderAgencyToFolioLocationsCreateEditRoute({
+        history,
+        mutator: newMutatorMock,
+      });
+      await act(async () => { await AgencyToFolioLocationsForm.mock.calls[1][0].onChangeServer(servers[0].name); });
+      expect(AgencyToFolioLocationsForm.mock.calls[6][0].bannerMessage).not.toBe('');
+    });
+
+    it('should be invisible', async () => {
+      renderAgencyToFolioLocationsCreateEditRoute({ history });
+      await act(async () => { await AgencyToFolioLocationsForm.mock.calls[1][0].onChangeServer(servers[0].name); });
+      expect(AgencyToFolioLocationsForm.mock.calls[5][0].bannerMessage).toBe('');
+    });
+  });
 });

--- a/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.test.js
+++ b/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.test.js
@@ -441,13 +441,13 @@ describe('AgencyToFolioLocationsCreateEditRoute component', () => {
         mutator: newMutatorMock,
       });
       await act(async () => { await AgencyToFolioLocationsForm.mock.calls[1][0].onChangeServer(servers[0].name); });
-      expect(AgencyToFolioLocationsForm.mock.calls[6][0].bannerMessage).not.toBe('');
+      expect(AgencyToFolioLocationsForm.mock.calls[6][0].localServersFailed).toBeTruthy();
     });
 
     it('should be invisible', async () => {
       renderAgencyToFolioLocationsCreateEditRoute({ history });
       await act(async () => { await AgencyToFolioLocationsForm.mock.calls[1][0].onChangeServer(servers[0].name); });
-      expect(AgencyToFolioLocationsForm.mock.calls[5][0].bannerMessage).toBe('');
+      expect(AgencyToFolioLocationsForm.mock.calls[5][0].localServersFailed).toBeFalsy();
     });
   });
 });

--- a/src/settings/routes/MaterialTypeRoute/MaterialTypeCreateEditRoute.js
+++ b/src/settings/routes/MaterialTypeRoute/MaterialTypeCreateEditRoute.js
@@ -10,6 +10,7 @@ import {
 } from 'lodash';
 import {
   FormattedMessage,
+  useIntl,
 } from 'react-intl';
 
 import {
@@ -69,11 +70,13 @@ const MaterialTypeCreateEditRoute = ({
   ] = useCentralServers(history, servers);
 
   const showCallout = useCallout();
+  const { formatMessage } = useIntl();
   const [materialTypeMappings, setMaterialTypeMappings] = useState([]);
   const [innReachItemTypes, setInnReachItemTypes] = useState([]);
   const [initialValues, setInitialValues] = useState({});
   const [isMaterialTypeMappingsPending, setIsMaterialTypeMappingsPending] = useState(false);
   const [isInnReachItemTypesPending, setIsInnReachItemTypesPending] = useState(false);
+  const [bannerMessage, setBannerMessage] = useState('');
 
   const getFormatedInnReachItemTypeOptions = useMemo(() => {
     let options = [];
@@ -97,6 +100,11 @@ const MaterialTypeCreateEditRoute = ({
     label: type.name,
     value: type.id,
   })), [materialTypes]);
+
+  const changeServer = (serverName) => {
+    setBannerMessage('');
+    handleServerChange(serverName);
+  };
 
   useEffect(() => {
     if (!isMaterialTypeMappingsPending && !isInnReachItemTypesPending) {
@@ -155,7 +163,12 @@ const MaterialTypeCreateEditRoute = ({
 
       mutator.innReachItemTypes.GET()
         .then(response => setInnReachItemTypes(response.itemTypeList))
-        .catch(() => setInnReachItemTypes([]))
+        .catch(() => {
+          const message = formatMessage({ id: 'ui-inn-reach.banner.item-types' });
+
+          setBannerMessage(message);
+          setInnReachItemTypes([]);
+        })
         .finally(() => setIsInnReachItemTypesPending(false));
     }
   }, [selectedServer.id]);
@@ -181,10 +194,11 @@ const MaterialTypeCreateEditRoute = ({
         initialValues={initialValues}
         isResetForm={isResetForm}
         innReachItemTypeOptions={getFormatedInnReachItemTypeOptions}
+        bannerMessage={bannerMessage}
         onSubmit={handleSubmit}
         onChangePristineState={changePristineState}
         onChangeFormResetState={changeFormResetState}
-        onChangeServer={handleServerChange}
+        onChangeServer={changeServer}
       />
     </>
   );

--- a/src/settings/routes/MaterialTypeRoute/MaterialTypeCreateEditRoute.js
+++ b/src/settings/routes/MaterialTypeRoute/MaterialTypeCreateEditRoute.js
@@ -10,7 +10,6 @@ import {
 } from 'lodash';
 import {
   FormattedMessage,
-  useIntl,
 } from 'react-intl';
 
 import {
@@ -70,13 +69,12 @@ const MaterialTypeCreateEditRoute = ({
   ] = useCentralServers(history, servers);
 
   const showCallout = useCallout();
-  const { formatMessage } = useIntl();
   const [materialTypeMappings, setMaterialTypeMappings] = useState([]);
   const [innReachItemTypes, setInnReachItemTypes] = useState([]);
   const [initialValues, setInitialValues] = useState({});
   const [isMaterialTypeMappingsPending, setIsMaterialTypeMappingsPending] = useState(false);
   const [isInnReachItemTypesPending, setIsInnReachItemTypesPending] = useState(false);
-  const [bannerMessage, setBannerMessage] = useState('');
+  const [innReachItemTypesFailed, setInnReachItemTypesFailed] = useState(false);
 
   const getFormatedInnReachItemTypeOptions = useMemo(() => {
     let options = [];
@@ -102,7 +100,7 @@ const MaterialTypeCreateEditRoute = ({
   })), [materialTypes]);
 
   const changeServer = (serverName) => {
-    setBannerMessage('');
+    setInnReachItemTypesFailed(false);
     handleServerChange(serverName);
   };
 
@@ -164,9 +162,7 @@ const MaterialTypeCreateEditRoute = ({
       mutator.innReachItemTypes.GET()
         .then(response => setInnReachItemTypes(response.itemTypeList))
         .catch(() => {
-          const message = formatMessage({ id: 'ui-inn-reach.banner.item-types' });
-
-          setBannerMessage(message);
+          setInnReachItemTypesFailed(true);
           setInnReachItemTypes([]);
         })
         .finally(() => setIsInnReachItemTypesPending(false));
@@ -194,7 +190,7 @@ const MaterialTypeCreateEditRoute = ({
         initialValues={initialValues}
         isResetForm={isResetForm}
         innReachItemTypeOptions={getFormatedInnReachItemTypeOptions}
-        bannerMessage={bannerMessage}
+        innReachItemTypesFailed={innReachItemTypesFailed}
         onSubmit={handleSubmit}
         onChangePristineState={changePristineState}
         onChangeFormResetState={changeFormResetState}

--- a/src/settings/routes/MaterialTypeRoute/MaterialTypeCreateEditRoute.test.js
+++ b/src/settings/routes/MaterialTypeRoute/MaterialTypeCreateEditRoute.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import { cloneDeep } from 'lodash';
 
 import { createMemoryHistory } from 'history';
-import { waitFor, screen } from '@testing-library/react';
+import { waitFor, screen, act } from '@testing-library/react';
 
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 import { ConfirmationModal } from '@folio/stripes-components';
@@ -101,6 +102,15 @@ const resourcesMock = {
   }
 };
 
+const innReachItemTypes = {
+  itemTypeList: [
+    {
+      centralItemType: 200,
+      description: 'Book',
+    }
+  ],
+};
+
 const putMock = jest.fn(() => Promise.resolve());
 const getMock = jest.fn(() => Promise.resolve());
 const replaceMock = jest.fn();
@@ -114,7 +124,7 @@ const mutatorMock = {
     PUT: putMock,
   },
   innReachItemTypes: {
-    GET: getMock,
+    GET: jest.fn(() => Promise.resolve(innReachItemTypes)),
   },
 };
 
@@ -186,6 +196,26 @@ describe('MaterialTypeCreateEditRoute component', () => {
         renderMaterialTypesCreateEditRoute({ history });
       });
       expect(screen.getByText('MaterialTypeForm')).toBeVisible();
+    });
+  });
+
+  describe('banner', () => {
+    it('should be visible', async () => {
+      const newMutatorMock = cloneDeep(mutatorMock);
+
+      newMutatorMock.innReachItemTypes.GET = jest.fn(() => Promise.reject());
+      renderMaterialTypesCreateEditRoute({
+        history,
+        mutator: newMutatorMock,
+      });
+      await act(async () => { await MaterialTypeForm.mock.calls[1][0].onChangeServer(servers[0].name); });
+      expect(MaterialTypeForm.mock.calls[6][0].bannerMessage).not.toBe('');
+    });
+
+    it('should be invisible', async () => {
+      renderMaterialTypesCreateEditRoute({ history });
+      await act(async () => { await MaterialTypeForm.mock.calls[1][0].onChangeServer(servers[0].name); });
+      expect(MaterialTypeForm.mock.calls[5][0].bannerMessage).toBe('');
     });
   });
 });

--- a/src/settings/routes/MaterialTypeRoute/MaterialTypeCreateEditRoute.test.js
+++ b/src/settings/routes/MaterialTypeRoute/MaterialTypeCreateEditRoute.test.js
@@ -209,13 +209,13 @@ describe('MaterialTypeCreateEditRoute component', () => {
         mutator: newMutatorMock,
       });
       await act(async () => { await MaterialTypeForm.mock.calls[1][0].onChangeServer(servers[0].name); });
-      expect(MaterialTypeForm.mock.calls[6][0].bannerMessage).not.toBe('');
+      expect(MaterialTypeForm.mock.calls[6][0].innReachItemTypesFailed).toBeTruthy();
     });
 
     it('should be invisible', async () => {
       renderMaterialTypesCreateEditRoute({ history });
       await act(async () => { await MaterialTypeForm.mock.calls[1][0].onChangeServer(servers[0].name); });
-      expect(MaterialTypeForm.mock.calls[5][0].bannerMessage).toBe('');
+      expect(MaterialTypeForm.mock.calls[5][0].innReachItemTypesFailed).toBeFalsy();
     });
   });
 });

--- a/translations/ui-inn-reach/en.json
+++ b/translations/ui-inn-reach/en.json
@@ -11,6 +11,9 @@
   "action.remove-fields": "{label} {index} has been removed. {fieldsLength} in total",
   "action.swap": "{label} {from} and {to} have been swapped",
 
+  "banner.local-servers": "Unable to retrieve local server settings from central server. Please verify the configuration of the selected central server.",
+  "banner.item-types": "Unable to retrieve INN-Reach item type settings from central server. Please verify the configuration of the selected central server.",
+
   "settings.title": "INN-Reach",
   "settings.central-servers.list.title": "Central servers",
   "settings.central-servers.view.title": "View {name}",

--- a/translations/ui-inn-reach/en_US.json
+++ b/translations/ui-inn-reach/en_US.json
@@ -11,6 +11,9 @@
   "action.remove-fields": "{label} {index} has been removed. {fieldsLength} in total",
   "action.swap": "{label} {from} and {to} have been swapped",
 
+  "banner.local-servers": "Unable to retrieve local server settings from central server. Please verify the configuration of the selected central server.",
+  "banner.item-types": "Unable to retrieve INN-Reach item type settings from central server. Please verify the configuration of the selected central server.",
+
   "settings.title": "INN-Reach",
   "settings.central-servers.list.title": "Central servers",
   "settings.central-servers.view.title": "View {name}",


### PR DESCRIPTION
- added a banner with an error when we don't have a response from local servers
- added a banner with an error when we don't have a response from item types