### PR TITLE
UIINREACH-111 use correct css-loader syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.2.0] (IN PROGRESS)
 
+* Use correct `css-loader` syntax. Refs UIINREACH-111.
 
 ## [1.1.0](https://github.com/folio-org/ui-inn-reach/tree/v1.1.0) (2021-10-08)
 

--- a/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/CentralServersConfigurationForm.css
+++ b/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/CentralServersConfigurationForm.css
@@ -7,7 +7,7 @@
 }
 
 .formControl {
-  composes: formControl isDisabled from '@folio/stripes-components/lib/sharedStyles/form.css'; /* stylelint-disable-line value-keyword-case */
+  composes: formControl isDisabled from '~@folio/stripes-components/lib/sharedStyles/form.css'; /* stylelint-disable-line value-keyword-case */
 }
 
 .inputGroup input {


### PR DESCRIPTION
Use the correct syntax when linking to styles in other packages.

@Dmytro-Melnyshyn, @Godlevskyi: please merge this if it looks OK to you; I don't have privileges in this repository. Thanks!

Refs [UIINREACH-111](https://issues.folio.org/browse/UIINREACH-111), [STRIPES-770](https://issues.folio.org/browse/STRIPES-770)