### PR TITLE
UIINREACH-114: INN-Reach Record Contribution Settings: Exclude Locations Not Associated with a local Agency Code from the "FOLIO locations to exclude from contribution"

### DIFF
--- a/src/components/common/SearchAndFilter/components/FiltersPane/FiltersPane.test.js
+++ b/src/components/common/SearchAndFilter/components/FiltersPane/FiltersPane.test.js
@@ -5,6 +5,7 @@ import {
 import user from '@testing-library/user-event';
 
 import FiltersPane from './FiltersPane';
+import { translationsProperties } from '../../../../../../test/jest/helpers';
 
 const FILTERS = 'Filters';
 const COLLAPSE_FILTERS_BUTTON = 'Icon';
@@ -17,6 +18,7 @@ const renderFiltersPane = (props = {
   >
     {FILTERS}
   </FiltersPane>,
+  translationsProperties
 ));
 
 describe('FiltersPane', () => {

--- a/src/components/common/SearchAndFilter/components/ResetButton/ResetButton.test.js
+++ b/src/components/common/SearchAndFilter/components/ResetButton/ResetButton.test.js
@@ -3,13 +3,14 @@ import {
   renderWithIntl,
 } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 import user from '@testing-library/user-event';
-
+import { translationsProperties } from '../../../../../../test/jest/helpers';
 import ResetButton from './ResetButton';
 
 const renderResetButton = (props = {}) => (renderWithIntl(
   <ResetButton
     {...props}
   />,
+  translationsProperties
 ));
 
 describe('ResetButton', () => {

--- a/src/components/common/SearchAndFilter/components/ResultsPane/ResultsPane.test.js
+++ b/src/components/common/SearchAndFilter/components/ResultsPane/ResultsPane.test.js
@@ -4,7 +4,7 @@ import {
 } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 
 import { getFiltersCount } from '../../../../../utils';
-
+import { translationsProperties } from '../../../../../../test/jest/helpers';
 import ResultsPane from './ResultsPane';
 
 jest.mock('../../../../../utils', () => ({
@@ -19,9 +19,11 @@ const renderResultsPane = (props = {
 }) => (renderWithIntl(
   <ResultsPane
     {...props}
+    filters={{}}
   >
     {RESULTS}
   </ResultsPane>,
+  translationsProperties
 ));
 
 describe('ResultsPane', () => {

--- a/src/components/common/SearchAndFilter/components/SearchForm/SearchForm.test.js
+++ b/src/components/common/SearchAndFilter/components/SearchForm/SearchForm.test.js
@@ -6,7 +6,7 @@ import {
 import {
   SearchField,
 } from '@folio/stripes/components';
-
+import { translationsProperties } from '../../../../../../test/jest/helpers';
 import SearchForm from './SearchForm';
 
 jest.mock('@folio/stripes/components', () => {
@@ -24,6 +24,7 @@ const renderSearchForm = ({
     applySearch={applySearch}
     changeSearch={changeSearch}
   />,
+  translationsProperties
 ));
 
 describe('SearchForm', () => {

--- a/src/components/transaction/TransactionListFilters/TransactionListFilters.js
+++ b/src/components/transaction/TransactionListFilters/TransactionListFilters.js
@@ -23,7 +23,6 @@ import {
 } from '../../../constants';
 import {
   applyFiltersAdapter,
-  getCentralServerOptions,
   getCheckboxFilterOptions,
 } from '../../../utils';
 import {
@@ -31,6 +30,7 @@ import {
   getCentralServerAgencyOptions,
   getCentralServerPatronTypeOptions,
   getCentralServerItemTypeOptions,
+  getCentralServerOpts,
 } from './utils';
 
 const {
@@ -71,7 +71,7 @@ const TransactionListFilters = ({
 
   const getTransactionTypeDataOptions = useMemo(() => getCheckboxFilterOptions(TYPE, Object.values(TRANSACTION_TYPES)), []);
   const transactionStatusOptions = useMemo(() => getTransactionStatusOptions(Object.values(TRANSACTION_STATUSES)), []);
-  const centralServerOptions = useMemo(() => getCentralServerOptions(servers), [servers]);
+  const centralServerOptions = useMemo(() => getCentralServerOpts(servers), [servers]);
   const centralServerAgencyOptions = useMemo(() => getCentralServerAgencyOptions(centralServerAgencies), [centralServerAgencies]);
   const centralServerPatronTypeOptions = useMemo(() => getCentralServerPatronTypeOptions(centralServerPatronTypes), [centralServerPatronTypes]);
   const centralServerItemTypeOptions = useMemo(() => getCentralServerItemTypeOptions(centralServerItemTypes), [centralServerItemTypes]);
@@ -125,7 +125,7 @@ const TransactionListFilters = ({
       />
       <MultiChoiceFilter
         name={CENTRAL_ITEM_TYPE}
-        labelId="ui-inn-reach.transaction.itemType"
+        labelId="ui-inn-reach.transaction.innReachItemType"
         activeFilters={activeFilters[CENTRAL_ITEM_TYPE]}
         dataOptions={centralServerItemTypeOptions}
         onChange={adaptedApplyFilters}

--- a/src/components/transaction/TransactionListFilters/TransactionListFilters.test.js
+++ b/src/components/transaction/TransactionListFilters/TransactionListFilters.test.js
@@ -9,14 +9,14 @@ import {
 
 const centralServers = {
   centralServers: [
-    { id: '1', name: 'central server1' },
-    { id: '2', name: 'central server2' },
+    { id: '1', name: 'central server1', centralServerCode: 'd2ir' },
+    { id: '2', name: 'central server2', centralServerCode: '1234' },
   ]
 };
 
 const centralServerOptions = [
-  { id: '1', label: 'central server1', value: 'central server1' },
-  { id: '2', label: 'central server2', value: 'central server2' },
+  { id: '1', label: 'central server1 (d2ir)', value: 'd2ir' },
+  { id: '2', label: 'central server2 (1234)', value: '1234' },
 ];
 
 const transactionStatusOptions = [

--- a/src/components/transaction/TransactionListFilters/utils.js
+++ b/src/components/transaction/TransactionListFilters/utils.js
@@ -5,6 +5,14 @@ export const getTransactionStatusOptions = statuses => {
   }));
 };
 
+export const getCentralServerOpts = (servers) => {
+  return servers.map(({ id, name, centralServerCode }) => ({
+    id,
+    label: `${name} (${centralServerCode})`,
+    value: centralServerCode,
+  }));
+};
+
 export const getCentralServerAgencyOptions = (centralServerAgencies) => {
   return centralServerAgencies.map(({ centralServerCode, agencies }) => {
     return agencies.map(({ agencyCode, description }) => ({

--- a/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/components/TabularList/TabularList.test.js
+++ b/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/components/TabularList/TabularList.test.js
@@ -112,7 +112,6 @@ describe('TabularList component', () => {
     });
   });
 
-  /*
   describe('Filtering of FOLIO libraries', () => {
     it('should show all libraries', () => {
       const librariesCount = document.querySelectorAll('[id="multiselect-option-list-localAgencies[0].FOLIOLibraries-0"]>li').length;
@@ -130,5 +129,4 @@ describe('TabularList component', () => {
       expect(librariesCount).toBe(6);
     });
   });
-  */
 });

--- a/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/components/TabularList/TabularList.test.js
+++ b/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/components/TabularList/TabularList.test.js
@@ -114,17 +114,17 @@ describe('TabularList component', () => {
 
   describe('Filtering of FOLIO libraries', () => {
     it('should show all libraries', () => {
-      const librariesCount = document.querySelectorAll('[id="multiselect-option-list-localAgencies[0].FOLIOLibraries-0"]>ul>li').length;
+      const librariesCount = document.querySelectorAll('[id="multiselect-option-list-localAgencies[0].FOLIOLibraries-0"]>li').length;
 
       expect(librariesCount).toBe(7);
     });
 
     it('should show the filtered list of libraries', () => {
-      const firstLibrary = document.querySelector('[id="multiselect-option-list-localAgencies[0].FOLIOLibraries-0"]>ul>li');
+      const firstLibrary = document.querySelector('[id="multiselect-option-list-localAgencies[0].FOLIOLibraries-0"]>li');
 
       firstLibrary.click();
       userEvent.click(screen.getByRole('button', { name: 'Add a new row' }));
-      const librariesCount = document.querySelectorAll('[id="multiselect-option-list-localAgencies[1].FOLIOLibraries-1"]>ul>li').length;
+      const librariesCount = document.querySelectorAll('[id="multiselect-option-list-localAgencies[1].FOLIOLibraries-1"]>li').length;
 
       expect(librariesCount).toBe(6);
     });

--- a/src/settings/components/ContributionCriteria/ContributionCriteriaForm/ContributionCriteriaForm.js
+++ b/src/settings/components/ContributionCriteria/ContributionCriteriaForm/ContributionCriteriaForm.js
@@ -60,7 +60,9 @@ const ContributionCriteriaForm = ({
   onChangeServer,
 }) => {
   const { formatMessage } = useIntl();
-  const folioLocationOptions = useMemo(() => getFolioLocations(folioLocations), [folioLocations]);
+  const folioLocationOptions = useMemo(() => {
+    return getFolioLocations(folioLocations, selectedServer.localAgencies);
+  }, [folioLocations, selectedServer.localAgencies]);
   const statisticalCodeOptions = useMemo(() => {
     return getStatisticalCodeOptions(formatMessage, values, statisticalCodes, statisticalCodeTypes);
   }, [statisticalCodes, statisticalCodeTypes, formatMessage, values]);
@@ -119,6 +121,7 @@ const ContributionCriteriaForm = ({
             <Col sm={12}>
               <Field
                 name={LOCATIONS_IDS}
+                id={LOCATIONS_IDS}
                 component={MultiSelection}
                 dataOptions={folioLocationOptions}
                 label={<FormattedMessage id="ui-inn-reach.settings.contribution-criteria.field.locations" />}

--- a/src/settings/components/ContributionCriteria/ContributionCriteriaForm/ContributionCriteriaForm.test.js
+++ b/src/settings/components/ContributionCriteria/ContributionCriteriaForm/ContributionCriteriaForm.test.js
@@ -143,7 +143,7 @@ describe('ContributionCriteriaForm', () => {
       ...commonProps,
       selectedServer: serverOptions[0],
     });
-    const libraryOptions = document.querySelectorAll('[id="multiselect-option-list-locationIds"]>ul>li');
+    const libraryOptions = document.querySelectorAll('[id="multiselect-option-list-locationIds"]>li');
 
     expect(libraryOptions.length).toBe(1);
     expect(screen.getByText('Annex'));

--- a/src/settings/components/ContributionCriteria/ContributionCriteriaForm/ContributionCriteriaForm.test.js
+++ b/src/settings/components/ContributionCriteria/ContributionCriteriaForm/ContributionCriteriaForm.test.js
@@ -12,11 +12,13 @@ import { CENTRAL_SERVER_ID } from '../../../../constants';
 const folioLocations = [
   {
     id: 1,
-    name: 'testLocation1',
+    name: 'Annex',
+    libraryId: '5d78803e-ca04-4b4a-aeae-2c63b924518b',
   },
   {
     id: 2,
-    name: 'testLocation2',
+    name: 'Online',
+    libraryId: 'c2549bb4-19c7-4fcc-8b52-39e612fb7dbe',
   }
 ];
 
@@ -40,11 +42,21 @@ const serverOptions = [
   {
     id: '5f552f82-91a8-4700-9814-988826d825c9',
     value: 'testName',
+    localAgencies: [
+      {
+        folioLibraryIds: ['5d78803e-ca04-4b4a-aeae-2c63b924518b'],
+      },
+    ],
     label: 'testName'
   },
   {
     id: '0b3a1862-ef3c-4ef4-beba-f6444069a5f5',
     value: 'testName2',
+    localAgencies: [
+      {
+        folioLibraryIds: ['c2549bb4-19c7-4fcc-8b52-39e612fb7dbe'],
+      },
+    ],
     label: 'testName2'
   }
 ];
@@ -124,6 +136,17 @@ describe('ContributionCriteriaForm', () => {
       isResetForm: true,
     });
     expect(onChangeFormResetState).toHaveBeenCalledWith(false);
+  });
+
+  it('should only have locations of the selected central server', () => {
+    renderContributionCriteriaForm({
+      ...commonProps,
+      selectedServer: serverOptions[0],
+    });
+    const libraryOptions = document.querySelectorAll('[id="multiselect-option-list-locationIds"]>ul>li');
+
+    expect(libraryOptions.length).toBe(1);
+    expect(screen.getByText('Annex'));
   });
 
   describe('`FOLIO statistical code to exclude from contribution` field', () => {

--- a/src/settings/components/ContributionCriteria/ContributionCriteriaForm/utils.js
+++ b/src/settings/components/ContributionCriteria/ContributionCriteriaForm/utils.js
@@ -12,8 +12,21 @@ const {
   CONTRIBUTE_AS_SYSTEM_OWNED_ID,
 } = CONTRIBUTION_CRITERIA;
 
-export const getFolioLocations = (folioLocations) => {
-  return folioLocations.map(({ id, name }) => ({
+const getServerLibIdsSet = (localAgencies) => {
+  return localAgencies.reduce((accum, { folioLibraryIds }) => {
+    folioLibraryIds.forEach(libId => {
+      accum.add(libId);
+    });
+
+    return accum;
+  }, new Set());
+};
+
+export const getFolioLocations = (folioLocations, localAgencies = []) => {
+  const serverLibIdsSet = getServerLibIdsSet(localAgencies);
+  const filteredFolioLocations = folioLocations.filter(location => serverLibIdsSet.has(location.libraryId));
+
+  return filteredFolioLocations.map(({ id, name }) => ({
     label: name,
     value: id,
   }));

--- a/translations/ui-inn-reach/en.json
+++ b/translations/ui-inn-reach/en.json
@@ -327,9 +327,9 @@
   "transaction.transactionStatus": "Transaction status",
   "transaction.centralServer": "Central server",
   "transaction.patronAgency": "Patron agency",
+  "transaction.innReachItemType": "INN-Reach item type",
   "transaction.itemAgency": "Item agency",
   "transaction.patronType": "INN-Reach patron type",
-  "transaction.itemType": "INN-Reach item type",
 
   "title.list.transactions": "INN-Reach transactions",
   "search": "Search",


### PR DESCRIPTION
- displayed the location of only the selected central server in the 'Contribution criteria' setting
- changed the name of the 'INN Reach material type' filter
- changed the options for the 'central server' filter and the request value