### PR TITLE
UIINREACH-127 use supported uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [1.3.0] (IN PROGRESS)
 
+* Use supported `uuid`. Refs UIINREACH-127.
+
 ## [1.2.0] (https://github.com/folio-org/ui-inn-reach/tree/v1.2.0) (2021-11-12)
 
 * Added recall user permissions. Refs UIINREACH-117.

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "@testing-library/user-event": "^12.1.10",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^26.3.0",
-    "history": "^5.0.0",
     "babel-polyfill": "^6.26.0",
     "core-js": "^3.6.1",
     "eslint": "^6.2.1",
     "eslint-plugin-jest": "^24.1.3",
+    "history": "^5.0.0",
     "identity-obj-proxy": "^3.0.0",
     "inflected": "^2.0.4",
     "jest": "^26.4.2",
@@ -63,16 +63,16 @@
     "prop-types": "^15.6.0",
     "react-final-form": "^6.3.0",
     "react-final-form-arrays": "^3.1.0",
-    "uuid": "^3.0.2"
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "@folio/stripes": "^7.0.0",
+    "query-string": "^5.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",
     "react-router": "*",
-    "react-router-dom": "^5.2.0",
-    "query-string": "^5.0.0"
+    "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {
     "@folio/plugin-find-user": "^5.0.1"


### PR DESCRIPTION
Earlier versions of `uuid` cause a build warning.

Attn: @Dmytro-Melnyshyn, @Godlevskyi 

Refs [UIINREACH-127](https://issues.folio.org/browse/UIINREACH-127)