### PR TITLE
UIINREACH-79: INN-Reach Staff Interface: INN-Reach Transaction Detail View Action Menu (Patron hold) - Receive item

### DIFF
--- a/src/components/common/filters/MultiChoiceFilter/MultiChoiceFilter.test.js
+++ b/src/components/common/filters/MultiChoiceFilter/MultiChoiceFilter.test.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
-import userEvent from '@testing-library/user-event';
-
+import MultiSelectionFilter from '@folio/stripes-smart-components/lib/SearchAndSort/components/MultiSelectionFilter';
 import MultiChoiceFilter from './MultiChoiceFilter';
 import { translationsProperties } from '../../../../../test/jest/helpers';
+
+jest.mock('@folio/stripes-smart-components/lib/SearchAndSort/components/MultiSelectionFilter', () => {
+  return jest.fn(() => <div>MultiSelectionFilter</div>);
+});
 
 const dataOptionsMock = [
   { label: 'central server1', value: 'central server1' },
@@ -33,6 +36,10 @@ const renderMultiChoiceFilter = ({
 ));
 
 describe('MultiChoiceFilter', () => {
+  beforeEach(() => {
+    MultiSelectionFilter.mockClear();
+  });
+
   it('should display the correct filter name', () => {
     renderMultiChoiceFilter();
     expect(screen.getByText('Transaction status')).toBeVisible();
@@ -42,10 +49,7 @@ describe('MultiChoiceFilter', () => {
     const onChange = jest.fn();
 
     renderMultiChoiceFilter({ onChange });
-    userEvent.click(screen.getByText('central server1'));
-    expect(onChange).toHaveBeenCalledWith({
-      name: 'state',
-      values: ['central server1'],
-    });
+    MultiSelectionFilter.mock.calls[0][0].onChange();
+    expect(onChange).toHaveBeenCalled();
   });
 });

--- a/src/components/transaction/TransactionDetails/TransactionDetail.js
+++ b/src/components/transaction/TransactionDetails/TransactionDetail.js
@@ -43,12 +43,14 @@ const TransactionDetail = ({
   onClose,
   onTriggerUnshippedItemModal,
   onFetchReceiveUnshippedItem,
+  onFetchReceiveItem,
 }) => {
   const renderActionMenu = useCallback(({ onToggle }) => (
     <ActionMenu
       transaction={transaction}
       onToggle={onToggle}
       onReceiveUnshippedItem={onTriggerUnshippedItemModal}
+      onReceiveItem={onFetchReceiveItem}
     />
   ), [transaction]);
 
@@ -92,6 +94,7 @@ TransactionDetail.propTypes = {
   isOpenUnshippedItemModal: PropTypes.bool.isRequired,
   transaction: PropTypes.object.isRequired,
   onClose: PropTypes.func.isRequired,
+  onFetchReceiveItem: PropTypes.func.isRequired,
   onFetchReceiveUnshippedItem: PropTypes.func.isRequired,
   onTriggerUnshippedItemModal: PropTypes.func.isRequired,
 };

--- a/src/components/transaction/TransactionDetails/TransactionDetail.test.js
+++ b/src/components/transaction/TransactionDetails/TransactionDetail.test.js
@@ -24,6 +24,7 @@ const renderTransactionDetail = ({
   isOpenUnshippedItemModal = false,
   onTriggerUnshippedItemModal,
   onFetchReceiveUnshippedItem,
+  onFetchReceiveItem,
   onClose,
 } = {}) => {
   return renderWithIntl(
@@ -34,6 +35,7 @@ const renderTransactionDetail = ({
       onClose={onClose}
       onTriggerUnshippedItemModal={onTriggerUnshippedItemModal}
       onFetchReceiveUnshippedItem={onFetchReceiveUnshippedItem}
+      onFetchReceiveItem={onFetchReceiveItem}
     />,
     translationsProperties,
   );
@@ -43,11 +45,13 @@ describe('TransactionDetail', () => {
   const onClose = jest.fn();
   const onTriggerUnshippedItemModal = jest.fn();
   const onFetchReceiveUnshippedItem = jest.fn();
+  const onFetchReceiveItem = jest.fn();
 
   const commonProps = {
     onClose,
     onTriggerUnshippedItemModal,
     onFetchReceiveUnshippedItem,
+    onFetchReceiveItem,
   };
 
   it('should be rendered', () => {

--- a/src/components/transaction/TransactionDetails/TransactionDetailContainer.js
+++ b/src/components/transaction/TransactionDetails/TransactionDetailContainer.js
@@ -75,7 +75,23 @@ const TransactionDetailContainer = ({
       });
   };
 
-  const handleSubmit = ({ itemBarcode }) => {
+  const fetchReceiveItem = () => {
+    mutator.receiveItem.POST({})
+      .then(() => {
+        onUpdateTransactionList();
+        showCallout({
+          message: <FormattedMessage id="ui-inn-reach.receive-item.callout.success.post.receive-item" />,
+        });
+      })
+      .catch(() => {
+        showCallout({
+          type: CALLOUT_ERROR_TYPE,
+          message: <FormattedMessage id="ui-inn-reach.receive-item.callout.connection-problem.post.receive-item" />,
+        });
+      });
+  };
+
+  const handleFetchReceiveUnshippedItem = ({ itemBarcode }) => {
     setIsOpenUnshippedItemModal(false);
     mutator.itemBarcode.replace(itemBarcode || '');
     fetchReceiveUnshippedItem();
@@ -95,7 +111,8 @@ const TransactionDetailContainer = ({
       isOpenUnshippedItemModal={isOpenUnshippedItemModal}
       onClose={backToList}
       onTriggerUnshippedItemModal={triggerUnshippedItemModal}
-      onFetchReceiveUnshippedItem={handleSubmit}
+      onFetchReceiveUnshippedItem={handleFetchReceiveUnshippedItem}
+      onFetchReceiveItem={fetchReceiveItem}
     />
   );
 };
@@ -112,6 +129,15 @@ TransactionDetailContainer.manifest = Object.freeze({
   receiveUnshippedItem: {
     type: 'okapi',
     path: 'inn-reach/transactions/%{transactionId}/receive-unshipped-item/%{servicePointId}/%{itemBarcode}',
+    pk: '',
+    clientGeneratePk: false,
+    fetch: false,
+    accumulate: true,
+    throwErrors: false,
+  },
+  receiveItem: {
+    type: 'okapi',
+    path: 'inn-reach/transactions/%{transactionId}/receive-item/%{servicePointId}',
     pk: '',
     clientGeneratePk: false,
     fetch: false,
@@ -142,6 +168,9 @@ TransactionDetailContainer.propTypes = {
       replace: PropTypes.func.isRequired,
     }).isRequired,
     receiveUnshippedItem: PropTypes.shape({
+      POST: PropTypes.func.isRequired,
+    }),
+    receiveItem: PropTypes.shape({
       POST: PropTypes.func.isRequired,
     }),
   }),

--- a/src/components/transaction/TransactionDetails/TransactionDetailContainer.js
+++ b/src/components/transaction/TransactionDetails/TransactionDetailContainer.js
@@ -38,6 +38,7 @@ const TransactionDetailContainer = ({
   stripes,
   history,
   location,
+  onUpdateTransactionList,
 }) => {
   const transaction = transactionData[0] || {};
   const servicePointId = stripes?.user?.user?.curServicePoint?.id;
@@ -61,6 +62,7 @@ const TransactionDetailContainer = ({
   const fetchReceiveUnshippedItem = () => {
     mutator.receiveUnshippedItem.POST({})
       .then(() => {
+        onUpdateTransactionList();
         showCallout({
           message: <FormattedMessage id="ui-inn-reach.unshipped-item.callout.success.post.receive-unshipped-item" />,
         });
@@ -128,6 +130,7 @@ TransactionDetailContainer.propTypes = {
     }).isRequired,
   }).isRequired,
   stripes: stripesShape.isRequired,
+  onUpdateTransactionList: PropTypes.func.isRequired,
   mutator: PropTypes.shape({
     servicePointId: PropTypes.shape({
       replace: PropTypes.func.isRequired,

--- a/src/components/transaction/TransactionDetails/TransactionDetailContainer.test.js
+++ b/src/components/transaction/TransactionDetails/TransactionDetailContainer.test.js
@@ -75,6 +75,9 @@ const mutatorMock = {
   receiveUnshippedItem: {
     POST: jest.fn(() => Promise.resolve()),
   },
+  receiveItem: {
+    POST: jest.fn(() => Promise.resolve()),
+  },
 };
 
 const historyMock = createMemoryHistory();
@@ -173,6 +176,20 @@ describe('TransactionDetailContainer', () => {
     it('should write service point id to the redux', () => {
       renderTransactionDetailContainer({ ...commonProps, stripes });
       expect(mutatorMock.servicePointId.replace).toHaveBeenCalledWith(servicePointId);
+    });
+  });
+
+  describe('receive item', () => {
+    it('should update the transaction state', () => {
+      renderTransactionDetailContainer(commonProps);
+      TransactionDetail.mock.calls[0][0].onFetchReceiveItem();
+      expect(mutatorMock.receiveItem.POST).toHaveBeenCalled();
+    });
+
+    it('should update the transaction list', async () => {
+      renderTransactionDetailContainer(commonProps);
+      TransactionDetail.mock.calls[0][0].onFetchReceiveItem();
+      expect(onUpdateTransactionList).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/transaction/TransactionDetails/TransactionDetailContainer.test.js
+++ b/src/components/transaction/TransactionDetails/TransactionDetailContainer.test.js
@@ -86,6 +86,7 @@ const renderTransactionDetailContainer = ({
   mutator = mutatorMock,
   history = historyMock,
   stripes,
+  onUpdateTransactionList,
 } = {}) => {
   return renderWithIntl(
     <TransactionDetailContainer
@@ -94,13 +95,20 @@ const renderTransactionDetailContainer = ({
       history={history}
       location={{ pathname: '/' }}
       stripes={stripes}
+      onUpdateTransactionList={onUpdateTransactionList}
     />,
     translationsProperties,
   );
 };
 
 describe('TransactionDetailContainer', () => {
+  const onUpdateTransactionList = jest.fn();
   let stripes;
+
+  const commonProps = {
+    stripes,
+    onUpdateTransactionList,
+  };
 
   beforeEach(() => {
     stripes = cloneDeep(useStripes());
@@ -109,7 +117,7 @@ describe('TransactionDetailContainer', () => {
   });
 
   it('should be rendered', () => {
-    const { container } = renderTransactionDetailContainer({ stripes });
+    const { container } = renderTransactionDetailContainer(commonProps);
 
     expect(container).toBeVisible();
   });
@@ -119,8 +127,8 @@ describe('TransactionDetailContainer', () => {
 
     newResources.transactionView.isPending = true;
     renderTransactionDetailContainer({
+      ...commonProps,
       resources: newResources,
-      stripes,
     });
     expect(screen.getByText('LoadingPane')).toBeVisible();
   });
@@ -130,8 +138,8 @@ describe('TransactionDetailContainer', () => {
       const history = createMemoryHistory();
 
       renderTransactionDetailContainer({
+        ...commonProps,
         history,
-        stripes,
       });
       TransactionDetail.mock.calls[0][0].onClose();
       expect(history.location.pathname).toBe('/innreach/transactions');
@@ -140,24 +148,30 @@ describe('TransactionDetailContainer', () => {
 
   describe('receive unshipped modal', () => {
     it('should be open', () => {
-      renderTransactionDetailContainer({ stripes });
+      renderTransactionDetailContainer(commonProps);
       act(() => { TransactionDetail.mock.calls[0][0].onTriggerUnshippedItemModal(); });
       expect(TransactionDetail.mock.calls[1][0].isOpenUnshippedItemModal).toBeTruthy();
     });
 
     it('should update the transaction state', () => {
-      renderTransactionDetailContainer({ stripes });
+      renderTransactionDetailContainer(commonProps);
       TransactionDetail.mock.calls[0][0].onFetchReceiveUnshippedItem({ itemBarcode });
       expect(mutatorMock.receiveUnshippedItem.POST).toHaveBeenCalled();
     });
 
+    it('should update the transaction list', async () => {
+      renderTransactionDetailContainer(commonProps);
+      await TransactionDetail.mock.calls[0][0].onFetchReceiveUnshippedItem({ itemBarcode });
+      expect(onUpdateTransactionList).toHaveBeenCalled();
+    });
+
     it('should write transaction id to the redux', () => {
-      renderTransactionDetailContainer({ stripes });
+      renderTransactionDetailContainer(commonProps);
       expect(mutatorMock.transactionId.replace).toHaveBeenLastCalledWith(transactionMock.id);
     });
 
     it('should write service point id to the redux', () => {
-      renderTransactionDetailContainer({ stripes });
+      renderTransactionDetailContainer({ ...commonProps, stripes });
       expect(mutatorMock.servicePointId.replace).toHaveBeenCalledWith(servicePointId);
     });
   });

--- a/src/components/transaction/TransactionDetails/components/ActionMenu/ActionMenu.js
+++ b/src/components/transaction/TransactionDetails/components/ActionMenu/ActionMenu.js
@@ -25,6 +25,7 @@ const ActionMenu = ({
   transaction,
   onToggle,
   onReceiveUnshippedItem,
+  onReceiveItem,
 }) => {
   let actions;
 
@@ -35,6 +36,7 @@ const ActionMenu = ({
           transaction={transaction}
           onToggle={onToggle}
           onReceiveUnshippedItem={onReceiveUnshippedItem}
+          onReceiveItem={onReceiveItem}
         />
       );
       break;
@@ -58,6 +60,7 @@ const ActionMenu = ({
 
 ActionMenu.propTypes = {
   transaction: PropTypes.object.isRequired,
+  onReceiveItem: PropTypes.func.isRequired,
   onReceiveUnshippedItem: PropTypes.func.isRequired,
   onToggle: PropTypes.func.isRequired,
 };

--- a/src/components/transaction/TransactionDetails/components/ActionMenu/ActionMenu.test.js
+++ b/src/components/transaction/TransactionDetails/components/ActionMenu/ActionMenu.test.js
@@ -16,6 +16,7 @@ const renderActionMenu = ({
       transaction={transaction}
       onToggle={jest.fn()}
       onReceiveUnshippedItem={jest.fn()}
+      onReceiveItem={jest.fn()}
     />,
     translationsProperties,
   );

--- a/src/components/transaction/TransactionDetails/components/ActionMenu/components/PatronActions/PatronActions.js
+++ b/src/components/transaction/TransactionDetails/components/ActionMenu/components/PatronActions/PatronActions.js
@@ -16,6 +16,7 @@ const {
 const {
   PATRON_HOLD,
   TRANSFER,
+  ITEM_SHIPPED,
 } = TRANSACTION_STATUSES;
 
 const PatronActions = ({
@@ -37,7 +38,7 @@ const PatronActions = ({
         onClickHandler={onCheckOut}
       />
       <ActionItem
-        disabled
+        disabled={transaction[STATUS] !== ITEM_SHIPPED}
         icon={ICONS.RECEIVE}
         buttonTextTranslationKey="ui-inn-reach.transaction-detail.patron-type.action.receive-item"
         onToggle={onToggle}

--- a/src/hooks/useList.js
+++ b/src/hooks/useList.js
@@ -28,7 +28,7 @@ const useList = (isLoadingRightAway, queryLoadRecords, loadRecordsCB, resultCoun
   const [recordsOffset, setRecordsOffset] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
 
-  const loadRecords = useCallback(offset => {
+  const loadRecords = useCallback((offset, updateList) => {
     setIsLoading(true);
     const queryParams = queryString.parse(location.search);
     const filtersCount = getFiltersCount(queryParams);
@@ -40,6 +40,7 @@ const useList = (isLoadingRightAway, queryLoadRecords, loadRecordsCB, resultCoun
 
     return loadRecordsPromise.then(recordsResponse => {
       if (!offset) setRecordsCount(recordsResponse?.totalRecords);
+      if (updateList) return recordsResponse && setRecords(recordsResponse.transactions);
 
       return recordsResponse && loadRecordsCB(setRecords, recordsResponse);
     }).finally(() => setIsLoading(false));
@@ -52,6 +53,10 @@ const useList = (isLoadingRightAway, queryLoadRecords, loadRecordsCB, resultCoun
       .then(() => {
         setRecordsOffset(newOffset);
       });
+  };
+
+  const onUpdateList = () => {
+    loadRecords(recordsOffset, true);
   };
 
   const refreshList = useCallback(() => {
@@ -72,6 +77,7 @@ const useList = (isLoadingRightAway, queryLoadRecords, loadRecordsCB, resultCoun
     recordsCount,
     isLoading,
     onNeedMoreData,
+    onUpdateList,
     refreshList,
   };
 };

--- a/src/hooks/useList.test.js
+++ b/src/hooks/useList.test.js
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
+import { useLocation } from 'react-router-dom';
 import useList from './useList';
-import { useLocation } from "react-router-dom";
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -33,6 +33,7 @@ describe('useList hook', () => {
 
   it('should return records', () => {
     const { records } = result.current;
+
     expect(records).toEqual(recordsMock.transactions);
   });
 
@@ -42,14 +43,16 @@ describe('useList hook', () => {
 
   it('should return records count', () => {
     const { recordsCount } = result.current;
+
     expect(recordsCount).toEqual(recordsMock.totalRecords);
   });
 
   describe('onUpdateList callback', () => {
     beforeEach(async () => {
       const { onUpdateList } = result.current;
+
       loadRecordsCB.mockClear();
-      await act(async () => { onUpdateList() });
+      await act(async () => { onUpdateList(); });
     });
 
     it('should fetch records ', () => {
@@ -64,7 +67,8 @@ describe('useList hook', () => {
   describe('onNeedMoreData callback', () => {
     beforeEach(async () => {
       const { onNeedMoreData } = result.current;
-      await act(async () => { onNeedMoreData() });
+
+      await act(async () => { onNeedMoreData(); });
     });
 
     it('should fetch records ', () => {

--- a/src/hooks/useList.test.js
+++ b/src/hooks/useList.test.js
@@ -1,0 +1,78 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import useList from './useList';
+import { useLocation } from "react-router-dom";
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn().mockReturnValue({ search: '?type=PATRON' }),
+}));
+
+const recordsMock = {
+  transactions: [{ id: '1' }],
+  totalRecords: 1,
+};
+
+const loadRecordsCB = jest.fn((setTransactions, transactionsResponse) => {
+  setTransactions((prev) => [...prev, ...transactionsResponse.transactions]);
+});
+
+const resultCountIncrement = 100;
+
+describe('useList hook', () => {
+  let result;
+  const queryLoadRecords = jest.fn(() => Promise.resolve(recordsMock));
+
+  beforeEach(async () => {
+    loadRecordsCB.mockClear();
+    useLocation.mockClear();
+
+    await act(async () => {
+      result = await renderHook(() => useList(false, queryLoadRecords, loadRecordsCB, resultCountIncrement)).result;
+    });
+  });
+
+  it('should return records', () => {
+    const { records } = result.current;
+    expect(records).toEqual(recordsMock.transactions);
+  });
+
+  it('should call queryLoadRecords callback', () => {
+    expect(queryLoadRecords).toHaveBeenCalled();
+  });
+
+  it('should return records count', () => {
+    const { recordsCount } = result.current;
+    expect(recordsCount).toEqual(recordsMock.totalRecords);
+  });
+
+  describe('onUpdateList callback', () => {
+    beforeEach(async () => {
+      const { onUpdateList } = result.current;
+      loadRecordsCB.mockClear();
+      await act(async () => { onUpdateList() });
+    });
+
+    it('should fetch records ', () => {
+      expect(queryLoadRecords).toHaveBeenCalled();
+    });
+
+    it('should not call loadRecordsCB callback', () => {
+      expect(loadRecordsCB).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onNeedMoreData callback', () => {
+    beforeEach(async () => {
+      const { onNeedMoreData } = result.current;
+      await act(async () => { onNeedMoreData() });
+    });
+
+    it('should fetch records ', () => {
+      expect(queryLoadRecords).toHaveBeenCalled();
+    });
+
+    it('should call loadRecordsCB callback', () => {
+      expect(loadRecordsCB).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ export default function InnReach({
       >
         <Route
           path={`${path}/transactions/:id/view`}
-          component={TransactionDetailContainer}
+          render={props => <TransactionDetailContainer {...props} />}
         />
       </Route>
       <Route

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,43 +1,81 @@
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import { render } from '@testing-library/react';
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+import { screen, act } from '@testing-library/react';
 
 import { useStripes } from '@folio/stripes/core';
 
 import InnReach from './index';
+import { translationsProperties } from '../test/jest/helpers';
+import TransactionDetailContainer from './components/transaction/TransactionDetails';
 
 jest.mock('./settings', () => () => 'InnReachSettings');
+jest.mock('./components/transaction/TransactionDetails', () => jest.fn(() => <div>TransactionDetailContainer</div>));
+jest.mock('@folio/stripes-smart-components/lib/SearchAndSort/components/MultiSelectionFilter', () => {
+  return jest.fn(() => <div>MultiSelectionFilter</div>);
+});
 
-const renderSettingsRoutes = (props) => {
-  const history = createMemoryHistory();
-
-  return render(
-    <Router history={history}>
+const renderRoutes = (props) => {
+  return renderWithIntl(
+    <Router history={props.history || createMemoryHistory()}>
       <InnReach
-        {...props}
-        showSettings
         match={{
           path: '/',
           params: {},
           url: '',
         }}
+        {...props}
       />
-    </Router>
+    </Router>,
+    translationsProperties,
   );
 };
 
-describe('InnReach settings', () => {
+describe('InnReach', () => {
   let stripes;
 
   beforeEach(() => {
+    TransactionDetailContainer.mockClear();
     stripes = useStripes();
   });
 
-  it('should be rendered', () => {
-    const { container, getByText } = renderSettingsRoutes({ stripes });
+  describe('setting routes', () => {
+    it('should be rendered', () => {
+      const { container, getByText } = renderRoutes({ stripes, showSettings: true });
 
-    expect(container).toBeVisible();
-    expect(getByText('InnReachSettings')).toBeDefined();
+      expect(container).toBeVisible();
+      expect(getByText('InnReachSettings')).toBeDefined();
+    });
+  });
+
+  describe('application routes', () => {
+    describe('TransactionDetailContainer route', () => {
+      beforeEach(async () => {
+        const history = createMemoryHistory();
+
+        history.push('/innreach/transactions/388cd313-cc79-4b48-ba26-8ed84b306a7c/view');
+
+        await act(async () => {
+          renderRoutes({
+            stripes,
+            match: {
+              path: '/innreach',
+              params: {},
+              url: '/innreach',
+            },
+            history,
+          });
+        });
+      });
+
+      it('should be rendered', () => {
+        expect(screen.getByText('TransactionDetailContainer')).toBeVisible();
+      });
+
+      it('should have function to update transaction list', () => {
+        expect(TransactionDetailContainer.mock.calls[3][0].onUpdateTransactionList).toBeDefined();
+      });
+    });
   });
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -73,7 +73,7 @@ describe('InnReach', () => {
         expect(screen.getByText('TransactionDetailContainer')).toBeVisible();
       });
 
-      it('should have function to update transaction list', () => {
+      it('should have a callback to update the list of transactions', () => {
         expect(TransactionDetailContainer.mock.calls[3][0].onUpdateTransactionList).toBeDefined();
       });
     });

--- a/src/routes/transaction/TransactionListRoute.js
+++ b/src/routes/transaction/TransactionListRoute.js
@@ -1,5 +1,6 @@
 import React, {
   useCallback,
+  cloneElement,
 } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -48,10 +49,15 @@ const TransactionListRoute = ({
     recordsCount: transactionsCount,
     isLoading,
     onNeedMoreData,
+    onUpdateList: onUpdateTransactionList,
     refreshList,
   } = useList(false, loadTransactions, loadTransactionsCB, RESULT_COUNT_INCREMENT);
 
   useLocationReset(history, location, getTransactionListUrl(), refreshList);
+
+  const additionalProps = {
+    render: props => children.props.render({ ...props, onUpdateTransactionList }),
+  };
 
   return (
     <TransactionList
@@ -61,7 +67,7 @@ const TransactionListRoute = ({
       resetData={resetData}
       onNeedMoreData={onNeedMoreData}
     >
-      {children}
+      {cloneElement(children, additionalProps)}
     </TransactionList>
   );
 };

--- a/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/CentralServersConfigurationForm.test.js
+++ b/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/CentralServersConfigurationForm.test.js
@@ -13,6 +13,8 @@ import {
 } from '../../../../constants';
 import { CentralServersConfigurationContext } from '../../../../contexts';
 
+jest.mock('./components/TabularList', () => jest.fn(() => <div>TabularList</div>));
+
 const data = {
   folioLibraries: [
     {

--- a/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/components/TabularList/TabularList.test.js
+++ b/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/components/TabularList/TabularList.test.js
@@ -6,10 +6,16 @@ import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jes
 import StripesFinalFormWrapper from '@folio/stripes-final-form/lib/StripesFinalFormWrapper';
 import userEvent from '@testing-library/user-event';
 
+import { MultiSelection } from '@folio/stripes-components';
 import TabularList from './TabularList';
 import { translationsProperties } from '../../../../../../../test/jest/helpers';
 import { validateLocalAgency } from '../../utils';
 import { DEFAULT_VALUES } from '../../../../../routes/CentralServersConfigurationRoute/CentralServersConfigurationCreateEditContainer';
+
+jest.mock('@folio/stripes-components', () => ({
+  ...jest.requireActual('@folio/stripes-components'),
+  MultiSelection: jest.fn(() => <div>MultiSelection</div>),
+}));
 
 const validate = (values) => ({
   ...validateLocalAgency(values.localAgencies),
@@ -30,7 +36,9 @@ const librariesTypeOptions = [
 ];
 
 describe('TabularList component', () => {
-  beforeEach(() => (
+  beforeEach(() => {
+    MultiSelection.mockClear();
+
     renderWithIntl(
       <MemoryRouter>
         <StripesFinalFormWrapper
@@ -42,12 +50,12 @@ describe('TabularList component', () => {
         />
       </MemoryRouter>,
       translationsProperties,
-    )
-  ));
+    );
+  });
 
   it('should display first and second fields of the row', () => {
     expect(document.querySelector('[id="localAgencies[0].localAgency-0"]')).toBeVisible();
-    expect(document.querySelector('[id="localAgencies[0].FOLIOLibraries-0"]')).toBeVisible();
+    expect(screen.getByTestId('row').contains(screen.getByText('MultiSelection'))).toBeTruthy();
   });
 
   it('should display "add" button', () => {
@@ -109,24 +117,6 @@ describe('TabularList component', () => {
       userEvent.click(screen.getByRole('button', { name: 'Add a new row' }));
       userEvent.click(screen.getByRole('button', { name: 'Remove fields for row 1' }));
       expect(screen.getAllByTestId('row')).toHaveLength(1);
-    });
-  });
-
-  describe('Filtering of FOLIO libraries', () => {
-    it('should show all libraries', () => {
-      const librariesCount = document.querySelectorAll('[id="multiselect-option-list-localAgencies[0].FOLIOLibraries-0"]>li').length;
-
-      expect(librariesCount).toBe(7);
-    });
-
-    it('should show the filtered list of libraries', () => {
-      const firstLibrary = document.querySelector('[id="multiselect-option-list-localAgencies[0].FOLIOLibraries-0"]>li');
-
-      firstLibrary.click();
-      userEvent.click(screen.getByRole('button', { name: 'Add a new row' }));
-      const librariesCount = document.querySelectorAll('[id="multiselect-option-list-localAgencies[1].FOLIOLibraries-1"]>li').length;
-
-      expect(librariesCount).toBe(6);
     });
   });
 });

--- a/src/settings/components/ContributionCriteria/ContributionCriteriaForm/ContributionCriteriaForm.test.js
+++ b/src/settings/components/ContributionCriteria/ContributionCriteriaForm/ContributionCriteriaForm.test.js
@@ -4,10 +4,16 @@ import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
+import { MultiSelection } from '@folio/stripes-components';
 import { translationsProperties } from '../../../../../test/jest/helpers';
 import { DEFAULT_VALUES } from '../../../routes/ContributionCriteriaRoute/utils';
 import ContributionCriteriaForm from './ContributionCriteriaForm';
 import { CENTRAL_SERVER_ID } from '../../../../constants';
+
+jest.mock('@folio/stripes-components', () => ({
+  ...jest.requireActual('@folio/stripes-components'),
+  MultiSelection: jest.fn(() => <div>MultiSelection</div>),
+}));
 
 const folioLocations = [
   {
@@ -115,6 +121,10 @@ describe('ContributionCriteriaForm', () => {
     onChangeServer,
   };
 
+  beforeEach(() => {
+    MultiSelection.mockClear();
+  });
+
   it('should be rendered', () => {
     const { container } = renderContributionCriteriaForm(commonProps);
 
@@ -143,10 +153,8 @@ describe('ContributionCriteriaForm', () => {
       ...commonProps,
       selectedServer: serverOptions[0],
     });
-    const libraryOptions = document.querySelectorAll('[id="multiselect-option-list-locationIds"]>li');
-
-    expect(libraryOptions.length).toBe(1);
-    expect(screen.getByText('Annex'));
+    expect(MultiSelection.mock.calls[0][0].dataOptions.length).toBe(1);
+    expect(MultiSelection.mock.calls[0][0].dataOptions[0].label).toBe('Annex');
   });
 
   describe('`FOLIO statistical code to exclude from contribution` field', () => {

--- a/src/settings/components/ContributionOptions/ContributionOptionsForm/ContributionOptionsForm.test.js
+++ b/src/settings/components/ContributionOptions/ContributionOptionsForm/ContributionOptionsForm.test.js
@@ -10,6 +10,11 @@ import {
   STATUSES_LIST_OPTIONS,
 } from '../../../../constants';
 
+jest.mock('@folio/stripes-components', () => ({
+  ...jest.requireActual('@folio/stripes-components'),
+  MultiSelection: jest.fn(() => <div>MultiSelection</div>),
+}));
+
 const folioLocations = [
   {
     id: 1,

--- a/translations/ui-inn-reach/en.json
+++ b/translations/ui-inn-reach/en.json
@@ -432,5 +432,8 @@
   "unshipped-item.placeholder.enter-item-barcode": "Enter item barcode",
   "unshipped-item.button.submit": "Submit",
   "unshipped-item.callout.connection-problem.post.receive-unshipped-item": "There was an error updating the barcode for the transaction",
-  "unshipped-item.callout.success.post.receive-unshipped-item": "The barcode associated with the transaction has been updated"
+  "unshipped-item.callout.success.post.receive-unshipped-item": "The barcode associated with the transaction has been updated",
+
+  "receive-item.callout.success.post.receive-item": "Item has been successfully returned to owning site",
+  "receive-item.callout.connection-problem.post.receive-item": "There was a problem receiving the item"
 }


### PR DESCRIPTION
## Purpose
- add functionality for receiving the shipped item in the action menu of the transaction detail view
- update the list of transactions if the action of the detail view menu has changed the transaction and the changed value of the transaction is displayed in the list
- fixed test warnings

## Refs
https://issues.folio.org/browse/UIINREACH-79