### PR TITLE
UIINREACH-145: INN-Reach Staff Interface: Receive Shipped Item - modal window behavior

### DIFF
--- a/src/components/ReceiveShippedItem/ReceiveShippedItem.js
+++ b/src/components/ReceiveShippedItem/ReceiveShippedItem.js
@@ -86,12 +86,14 @@ const ReceiveShippedItems = ({
   const [isHoldItem, setIsHoldItem] = useState(false);
   const [isTransitItem, setIsTransitItem] = useState(false);
   const [checkinData, setCheckinData] = useState(null);
+  const [isAugmentedBarcodeModalAfterClose, setIsAugmentedBarcodeModalAfterClose] = useState(false);
 
   const showCallout = useCallout();
   const intl = useIntl();
   const itemFormRef = useRef({});
   const barcodeRef = useRef();
   const isLoading = isTransactionsPending || isReceiveShippedItemPending;
+  const showHoldOrTransitModal = !barcodeSupplemented || isAugmentedBarcodeModalAfterClose;
 
   const resetData = () => {
     if (itemFormRef.current.reset) {
@@ -106,6 +108,7 @@ const ReceiveShippedItems = ({
     setIsHoldItem(false);
     setIsTransitItem(false);
     setCheckinData(null);
+    setIsAugmentedBarcodeModalAfterClose(false);
   };
 
   const processResponse = (checkinResp) => {
@@ -194,6 +197,10 @@ const ReceiveShippedItems = ({
     return staffSlip?.template || '';
   };
 
+  const handleIsAugmentedBarcodeModalAfterClose = () => {
+    setIsAugmentedBarcodeModalAfterClose(true);
+  };
+
   const renderAugmentedBarcodeModal = () => {
     const {
       folioCheckIn: {
@@ -212,7 +219,7 @@ const ReceiveShippedItems = ({
         slipTemplate={AUGMENTED_BARCODE_TEMPLATE}
         slipData={slipData}
         message={messages}
-        onClose={handleCloseModal}
+        onClose={handleIsAugmentedBarcodeModalAfterClose}
         onAfterPrint={focusBarcodeField}
       />
     );
@@ -265,7 +272,7 @@ const ReceiveShippedItems = ({
     return (
       <ConfirmStatusModal
         showPrintButton
-        isPrintable
+        isPrintable={barcodeSupplemented}
         label={<FormattedMessage id="ui-inn-reach.shipped-items.modal.hold.heading" />}
         slipTemplate={getSlipTmpl('hold')}
         slipData={slipData}
@@ -304,7 +311,7 @@ const ReceiveShippedItems = ({
     return (
       <ConfirmStatusModal
         showPrintButton
-        isPrintable
+        isPrintable={barcodeSupplemented}
         label={<FormattedMessage id="ui-inn-reach.shipped-items.modal.transit.heading" />}
         slipTemplate={getSlipTmpl('transit')}
         slipData={slipData}
@@ -343,8 +350,8 @@ const ReceiveShippedItems = ({
       />
       {noTransaction && renderNoTransactionModal()}
       {barcodeSupplemented && renderAugmentedBarcodeModal()}
-      {isHoldItem && !barcodeSupplemented && renderHoldModal()}
-      {isTransitItem && renderTransitionModal()}
+      {isHoldItem && showHoldOrTransitModal && renderHoldModal()}
+      {isTransitItem && showHoldOrTransitModal && renderTransitionModal()}
     </>
   );
 };

--- a/src/components/ReceiveShippedItem/ReceiveShippedItem.js
+++ b/src/components/ReceiveShippedItem/ReceiveShippedItem.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import {
   upperFirst,
-  delay,
 } from 'lodash';
 
 import {
@@ -199,7 +198,7 @@ const ReceiveShippedItems = ({
   };
 
   const handleIsAugmentedBarcodeModalAfterClose = () => {
-    delay(() => setIsAugmentedBarcodeModalAfterClose(true), 200);
+    setIsAugmentedBarcodeModalAfterClose(true);
   };
 
   const renderAugmentedBarcodeModal = () => {

--- a/src/components/ReceiveShippedItem/ReceiveShippedItem.js
+++ b/src/components/ReceiveShippedItem/ReceiveShippedItem.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import {
   upperFirst,
+  delay,
 } from 'lodash';
 
 import {
@@ -198,8 +199,12 @@ const ReceiveShippedItems = ({
   };
 
   const handleIsAugmentedBarcodeModalAfterClose = () => {
-    setIsAugmentedBarcodeModalAfterClose(true);
+    delay(() => setIsAugmentedBarcodeModalAfterClose(true), 200);
   };
+
+  // const handleCloseAugmentedBarcodeModal = () => {
+  //   delay(() => setBarcodeSupplemented(false), 200);
+  // };
 
   const renderAugmentedBarcodeModal = () => {
     const {
@@ -215,12 +220,16 @@ const ReceiveShippedItems = ({
 
     return (
       <ConfirmStatusModal
+        isPrintable
+        showPrintButton
         label={<FormattedMessage id="ui-inn-reach.shipped-items.modal.barcode-augmented.heading" />}
+        checkboxLabel={<FormattedMessage id="ui-inn-reach.shipped-items.field.print-barcode-slip" />}
         slipTemplate={AUGMENTED_BARCODE_TEMPLATE}
         slipData={slipData}
         message={messages}
-        onClose={handleIsAugmentedBarcodeModalAfterClose}
-        onAfterPrint={focusBarcodeField}
+        onClose={handleCloseModal}
+        onClickClose={handleIsAugmentedBarcodeModalAfterClose}
+        onBeforePrint={handleIsAugmentedBarcodeModalAfterClose}
       />
     );
   };
@@ -272,7 +281,6 @@ const ReceiveShippedItems = ({
     return (
       <ConfirmStatusModal
         showPrintButton
-        isPrintable={barcodeSupplemented}
         label={<FormattedMessage id="ui-inn-reach.shipped-items.modal.hold.heading" />}
         slipTemplate={getSlipTmpl('hold')}
         slipData={slipData}
@@ -311,7 +319,6 @@ const ReceiveShippedItems = ({
     return (
       <ConfirmStatusModal
         showPrintButton
-        isPrintable={barcodeSupplemented}
         label={<FormattedMessage id="ui-inn-reach.shipped-items.modal.transit.heading" />}
         slipTemplate={getSlipTmpl('transit')}
         slipData={slipData}

--- a/src/components/ReceiveShippedItem/ReceiveShippedItem.js
+++ b/src/components/ReceiveShippedItem/ReceiveShippedItem.js
@@ -276,6 +276,7 @@ const ReceiveShippedItems = ({
 
     return (
       <ConfirmStatusModal
+        isPrintable
         showPrintButton
         label={<FormattedMessage id="ui-inn-reach.shipped-items.modal.hold.heading" />}
         slipTemplate={getSlipTmpl('hold')}
@@ -314,6 +315,7 @@ const ReceiveShippedItems = ({
 
     return (
       <ConfirmStatusModal
+        isPrintable
         showPrintButton
         label={<FormattedMessage id="ui-inn-reach.shipped-items.modal.transit.heading" />}
         slipTemplate={getSlipTmpl('transit')}

--- a/src/components/ReceiveShippedItem/components/CheckIn/components/ListCheckInItems/components/ItemActions/ItemActions.js
+++ b/src/components/ReceiveShippedItem/components/CheckIn/components/ListCheckInItems/components/ItemActions/ItemActions.js
@@ -68,7 +68,7 @@ const ItemActions = ({
           <FormattedMessage id="ui-inn-reach.shipped-items.action.print-inn-reach-barcode" />
         </PrintButton>
       }
-      {isHoldItem && !barcodeAugmented &&
+      {isHoldItem &&
         <PrintButton
           data-testid="print-hold-slip"
           role="menuitem"
@@ -79,7 +79,7 @@ const ItemActions = ({
           <FormattedMessage id="ui-inn-reach.shipped-items.action.print-hold-slip" />
         </PrintButton>
       }
-      {isTransitItem && !barcodeAugmented &&
+      {isTransitItem &&
         <PrintButton
           data-testid="print-transit-slip"
           role="menuitem"

--- a/src/components/ReceiveShippedItem/components/CheckIn/components/ListCheckInItems/components/ItemActions/ItemActions.js
+++ b/src/components/ReceiveShippedItem/components/CheckIn/components/ListCheckInItems/components/ItemActions/ItemActions.js
@@ -79,7 +79,7 @@ const ItemActions = ({
           <FormattedMessage id="ui-inn-reach.shipped-items.action.print-hold-slip" />
         </PrintButton>
       }
-      {isTransitItem &&
+      {isTransitItem && !barcodeAugmented &&
         <PrintButton
           data-testid="print-transit-slip"
           role="menuitem"

--- a/src/components/ReceiveShippedItem/components/CheckIn/components/ListCheckInItems/components/ItemActions/ItemActions.test.js
+++ b/src/components/ReceiveShippedItem/components/CheckIn/components/ListCheckInItems/components/ItemActions/ItemActions.test.js
@@ -58,15 +58,42 @@ describe('ItemActions', () => {
     expect(container).toBeVisible();
   });
 
-  it('should display "Print INN-Reach barcode" button', () => {
-    renderItemActions({
-      ...commonProps,
-      loan: {
-        ...loanMock,
-        barcodeAugmented: true,
-      },
+  describe('when barcode augmented', () => {
+    it('should display the "Print INN-Reach barcode" button', () => {
+      renderItemActions({
+        ...commonProps,
+        loan: {
+          ...loanMock,
+          barcodeAugmented: true,
+          isHoldItem: true,
+        },
+      });
+      expect(PrintButton.mock.calls[0][0]['data-testid']).toBe('print-inn-reach-barcode');
     });
-    expect(PrintButton.mock.calls[0][0]['data-testid']).toBe('print-inn-reach-barcode');
+
+    it('should display the "Print hold slip" button', () => {
+      renderItemActions({
+        ...commonProps,
+        loan: {
+          ...loanMock,
+          barcodeAugmented: true,
+          isHoldItem: true,
+        },
+      });
+      expect(PrintButton.mock.calls[1][0]['data-testid']).toBe('print-hold-slip');
+    });
+
+    it('should display the "Print transit slip" button', () => {
+      renderItemActions({
+        ...commonProps,
+        loan: {
+          ...loanMock,
+          barcodeAugmented: true,
+          isTransitItem: true,
+        },
+      });
+      expect(PrintButton.mock.calls[1][0]['data-testid']).toBe('print-transit-slip');
+    });
   });
 
   it('should display "Print hold slip" button', () => {

--- a/src/components/ReceiveShippedItem/components/ConfirmStatusModal/ConfirmStatusModal.js
+++ b/src/components/ReceiveShippedItem/components/ConfirmStatusModal/ConfirmStatusModal.js
@@ -90,7 +90,7 @@ const ConfirmStatusModal = ({
             <Checkbox
               checked={isPrint}
               name="printBarcodeSlip"
-              label={<FormattedMessage id="ui-inn-reach.shipped-items.field.print-barcode-slip" />}
+              label={<FormattedMessage id="ui-inn-reach.shipped-items.field.print-slip" />}
               value={isPrint + ''}
               onChange={triggerPrintBarcodeSlip}
             />

--- a/src/components/ReceiveShippedItem/components/ConfirmStatusModal/ConfirmStatusModal.js
+++ b/src/components/ReceiveShippedItem/components/ConfirmStatusModal/ConfirmStatusModal.js
@@ -28,8 +28,11 @@ const ConfirmStatusModal = ({
   slipTemplate,
   slipData,
   message,
+  checkboxLabel,
   onAfterPrint,
+  onBeforePrint,
   onClose,
+  onClickClose,
 }) => {
   const [isPrint, setIsPrint] = useState(isPrintable);
 
@@ -56,7 +59,7 @@ const ConfirmStatusModal = ({
             buttonStyle="primary"
             dataSource={slipData}
             template={slipTemplate}
-            onBeforePrint={onClose}
+            onBeforePrint={onBeforePrint || onClose}
             onAfterPrint={onAfterPrint}
           >
             <FormattedMessage id="ui-inn-reach.shipped-items.modal.button.close" />
@@ -66,7 +69,7 @@ const ConfirmStatusModal = ({
             marginBottom0
             data-testid="close-button"
             buttonStyle="primary"
-            onClick={onClose}
+            onClick={onClickClose || onClose}
           >
             <FormattedMessage id="ui-inn-reach.shipped-items.modal.button.close" />
           </Button>
@@ -90,7 +93,7 @@ const ConfirmStatusModal = ({
             <Checkbox
               checked={isPrint}
               name="printBarcodeSlip"
-              label={<FormattedMessage id="ui-inn-reach.shipped-items.field.print-slip" />}
+              label={checkboxLabel || <FormattedMessage id="ui-inn-reach.shipped-items.field.print-slip" />}
               value={isPrint + ''}
               onChange={triggerPrintBarcodeSlip}
             />
@@ -105,12 +108,15 @@ ConfirmStatusModal.propTypes = {
   label: PropTypes.node.isRequired,
   message: PropTypes.node.isRequired,
   onClose: PropTypes.func.isRequired,
+  checkboxLabel: PropTypes.node,
   isPrintable: PropTypes.bool,
   open: PropTypes.bool,
   showPrintButton: PropTypes.bool,
   slipData: PropTypes.object,
   slipTemplate: PropTypes.string,
   onAfterPrint: PropTypes.func,
+  onBeforePrint: PropTypes.func,
+  onClickClose: PropTypes.func,
 };
 
 ConfirmStatusModal.defaultProps = {

--- a/translations/ui-inn-reach/en.json
+++ b/translations/ui-inn-reach/en.json
@@ -435,6 +435,6 @@
   "unshipped-item.callout.connection-problem.post.receive-unshipped-item": "There was an error updating the barcode for the transaction",
   "unshipped-item.callout.success.post.receive-unshipped-item": "The barcode associated with the transaction has been updated",
 
-  "receive-item.callout.success.post.receive-item": "Item has been successfully returned to owning site",
-  "receive-item.callout.connection-problem.post.receive-item": "There was a problem receiving the item"
+  "receive-item.callout.connection-problem.post.receive-item": "There was a problem receiving the item",
+  "receive-item.callout.success.post.receive-item": "Item has been successfully received"
 }

--- a/translations/ui-inn-reach/en.json
+++ b/translations/ui-inn-reach/en.json
@@ -404,6 +404,7 @@
   "shipped-items.callout.connection-problem.get.transactions": "Unable to get data due to a module error. Please try again. If a problem persists please contact your system administrator",
   "shipped-items.callout.connection-problem.put.receive-shipped-item": "There was a problem receiving the item",
   "shipped-items.field.print-slip": "Print slip",
+  "shipped-items.field.print-barcode-slip": "Print barcode slip",
 
   "check-out-borrowing-site.title.check-out-borrowing-site": "Check out to borrowing site",
   "check-out-borrowing-site.title.scan-items": "Scan Items",

--- a/translations/ui-inn-reach/en.json
+++ b/translations/ui-inn-reach/en.json
@@ -401,9 +401,9 @@
   "shipped-items.action.print-inn-reach-barcode": "Print INN-Reach barcode",
   "shipped-items.action.print-hold-slip": "Print hold slip",
   "shipped-items.action.print-transit-slip": "Print transit slip",
-  "shipped-items.field.print-barcode-slip": "Print barcode slip",
   "shipped-items.callout.connection-problem.get.transactions": "Unable to get data due to a module error. Please try again. If a problem persists please contact your system administrator",
   "shipped-items.callout.connection-problem.put.receive-shipped-item": "There was a problem receiving the item",
+  "shipped-items.field.print-slip": "Print slip",
 
   "check-out-borrowing-site.title.check-out-borrowing-site": "Check out to borrowing site",
   "check-out-borrowing-site.title.scan-items": "Scan Items",


### PR DESCRIPTION
## Purpose
- to display two action buttons (`Print INN-Reach barcode` and `Print transit slip`) in the action menu `...` for the `augmented barcode` with the `In transit` status and two buttons (`Print INN-Reach barcode` and `Print hold slip`) for the `augmented barcode` with the `Awaiting pickup` status
- dismissing the first modal before the second is presented

## Refs
[UIINREACH-109 PO comment](https://issues.folio.org/browse/UIINREACH-109?focusedCommentId=122091&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-122091)
## Screenshots
![image](https://user-images.githubusercontent.com/77053927/151775416-f78cfdb4-b825-4aa1-8d06-f6085ee2ad00.png)
![image](https://user-images.githubusercontent.com/77053927/151775612-b485467c-0c47-4c88-bcea-ea4cbf9a027f.png)
