### PR TITLE
UIINREACH-100: FOLIO to INN-Reach Locations Settings Should Group Mappings by INN-Reach Agency

### DIFF
--- a/src/constants/central-server-configuration.js
+++ b/src/constants/central-server-configuration.js
@@ -9,7 +9,7 @@ export const CENTRAL_SERVER_CONFIGURATIONS_PATH = `/${SETTINGS_PATH}/${CENTRAL_S
 export const LOCAL_AGENCIES_FIELDS = {
   ID: 'id',
   CODE: 'code',
-  FOLIO_LIBRARY_IDs: 'folioLibraryIds',
+  FOLIO_LIBRARY_IDS: 'folioLibraryIds',
 };
 
 export const CENTRAL_SERVER_CONFIGURATION_FIELDS = {

--- a/src/constants/folio-to-innreach-locations.js
+++ b/src/constants/folio-to-innreach-locations.js
@@ -7,7 +7,8 @@ import {
 export const FOLIO_TO_INN_REACH_LOCATIONS_ROUTE = 'folio-to-inn-reach-locations';
 
 export const FOLIO_TO_INN_REACH_LOCATION_FIELDS = {
-  TABULAR_LIST: 'tabularList',
+  LIBRARIES_TABULAR_LIST: 'librariesTabularList',
+  LOCATIONS_TABULAR_LIST: 'locationsTabularList',
   LEFT_COLUMN: 'leftColumn',
   MAPPING_TYPE: 'mappingType',
   LIBRARY: 'library',

--- a/src/settings/components/CentralServersConfiguration/CentralServersConfigurationView/components/GeneralInformation/GeneralInformation.js
+++ b/src/settings/components/CentralServersConfiguration/CentralServersConfigurationView/components/GeneralInformation/GeneralInformation.js
@@ -47,17 +47,17 @@ const GeneralInformation = ({
 
   const visibleColumns = [
     LOCAL_AGENCIES_FIELDS.CODE,
-    LOCAL_AGENCIES_FIELDS.FOLIO_LIBRARY_IDs,
+    LOCAL_AGENCIES_FIELDS.FOLIO_LIBRARY_IDS,
   ];
 
   const columnMapping = {
     [LOCAL_AGENCIES_FIELDS.CODE]: <FormattedMessage id="ui-inn-reach.settings.central-server-configuration.local-agency.field.code" />,
-    [LOCAL_AGENCIES_FIELDS.FOLIO_LIBRARY_IDs]: <FormattedMessage id="ui-inn-reach.settings.central-server-configuration.local-agency.field.libraries" />,
+    [LOCAL_AGENCIES_FIELDS.FOLIO_LIBRARY_IDS]: <FormattedMessage id="ui-inn-reach.settings.central-server-configuration.local-agency.field.libraries" />,
   };
 
   const resultsFormatter = {
     [LOCAL_AGENCIES_FIELDS.CODE]: (data) => (data[LOCAL_AGENCIES_FIELDS.CODE] || <NoValue />),
-    [LOCAL_AGENCIES_FIELDS.FOLIO_LIBRARY_IDs]: (data) => getFormattedFolioLibraries(data.folioLibraryIds, folioLibraries),
+    [LOCAL_AGENCIES_FIELDS.FOLIO_LIBRARY_IDS]: (data) => getFormattedFolioLibraries(data.folioLibraryIds, folioLibraries),
   };
 
   return (

--- a/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/FolioToInnReachLocationsForm.css
+++ b/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/FolioToInnReachLocationsForm.css
@@ -1,3 +1,7 @@
 .tabularList {
   margin-bottom: 1rem;
 }
+
+.tabularListTitle {
+  font-size: 1.15rem;
+}

--- a/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/FolioToInnReachLocationsForm.css
+++ b/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/FolioToInnReachLocationsForm.css
@@ -1,0 +1,3 @@
+.tabularList {
+  margin-bottom: 1rem;
+}

--- a/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/FolioToInnReachLocationsForm.js
+++ b/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/FolioToInnReachLocationsForm.js
@@ -1,13 +1,10 @@
 import React, {
   useEffect,
   useMemo,
-  useState,
+  Fragment,
 } from 'react';
 import stripesFinalForm from '@folio/stripes/final-form';
 import PropTypes from 'prop-types';
-import {
-  isEqual,
-} from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import {
   Button,
@@ -18,17 +15,21 @@ import {
   Selection,
 } from '@folio/stripes-components';
 import {
+  CENTRAL_SERVER_CONFIGURATION_FIELDS,
   CENTRAL_SERVER_ID,
   DEFAULT_PANE_WIDTH,
   FOLIO_TO_INN_REACH_LOCATION_FIELDS,
+  LOCAL_AGENCIES_FIELDS,
 } from '../../../../constants';
 import {
+  getFilteredInnReachLocationOptions,
   getInnReachLocationOptions,
   validate,
 } from './utils';
 import {
   TableStyleList,
 } from '../../common';
+import css from './FolioToInnReachLocationsForm.css';
 
 const {
   MAPPING_TYPE,
@@ -36,8 +37,17 @@ const {
   INN_REACH_LOCATIONS,
   FOLIO_LIBRARY,
   FOLIO_LOCATION,
-  TABULAR_LIST,
+  LIBRARIES_TABULAR_LIST,
+  LOCATIONS_TABULAR_LIST,
 } = FOLIO_TO_INN_REACH_LOCATION_FIELDS;
+
+const {
+  CODE,
+} = LOCAL_AGENCIES_FIELDS;
+
+const {
+  LOCAL_AGENCIES,
+} = CENTRAL_SERVER_CONFIGURATION_FIELDS;
 
 const FolioToInnReachLocationsForm = ({
   selectedServer,
@@ -53,21 +63,16 @@ const FolioToInnReachLocationsForm = ({
   isShowTabularList,
   isResetForm,
   handleSubmit,
-  initialValues,
   values,
+  pristine,
+  invalid,
   form,
   onChangeFormResetState,
   onChangeServer,
   onChangeMappingType,
   onChangeLibrary,
 }) => {
-  const [isRequiredFieldsFilledIn, setIsRequiredFieldsFilledIn] = useState(false);
-
   const innReachLocationOptions = useMemo(() => getInnReachLocationOptions(innReachLocations), [innReachLocations]);
-
-  const leftColumnName = mappingType === librariesMappingType
-    ? FOLIO_LIBRARY
-    : FOLIO_LOCATION;
 
   const handleMappingTypeChange = (event) => {
     onChangeMappingType(event.target.value);
@@ -80,27 +85,7 @@ const FolioToInnReachLocationsForm = ({
     }
   }, [isResetForm]);
 
-  useEffect(() => {
-    const {
-      tabularList,
-    } = values;
-
-    if (tabularList) {
-      if (mappingType === librariesMappingType) {
-        const isAllFieldsFilledIn = tabularList.every(row => row[INN_REACH_LOCATIONS]);
-
-        setIsRequiredFieldsFilledIn(isAllFieldsFilledIn);
-      } else if (mappingType === locationsMappingType) {
-        const isSomeFieldFilledIn = tabularList.some(row => row[INN_REACH_LOCATIONS]);
-
-        setIsRequiredFieldsFilledIn(isSomeFieldFilledIn);
-      }
-    }
-  }, [values]);
-
   const getFooter = () => {
-    const isPristine = isEqual(initialValues[TABULAR_LIST], values[TABULAR_LIST]);
-
     const saveButton = (
       <Button
         marginBottom0
@@ -108,7 +93,7 @@ const FolioToInnReachLocationsForm = ({
         id="clickable-save-instance"
         buttonStyle="primary mega"
         type="submit"
-        disabled={isPristine || !isRequiredFieldsFilledIn}
+        disabled={pristine || invalid}
         onClick={handleSubmit}
       >
         <FormattedMessage id="ui-inn-reach.settings.contribution-criteria.button.save" />
@@ -152,22 +137,43 @@ const FolioToInnReachLocationsForm = ({
           />
         }
         {isMappingsPending && <Loading />}
-        {isShowTabularList &&
-          <TableStyleList
-            fieldArrayName={TABULAR_LIST}
-            leftTitle={leftColumnName === FOLIO_LIBRARY
-              ? <FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.libraries" />
-              : <FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.locations" />
-            }
-            rightTitle={<FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.inn-reach-locations" />}
-            leftFieldName={leftColumnName}
-            rightFieldName={INN_REACH_LOCATIONS}
-            dataOptions={innReachLocationOptions}
-            ariaLabel={<FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.inn-reach-locations" />}
-            requiredRightCol={leftColumnName === FOLIO_LIBRARY}
-            validate={validate}
-          />
-        }
+        {isShowTabularList && (
+          mappingType === librariesMappingType
+            ? selectedServer[LOCAL_AGENCIES].map((localAgency, index) => {
+              const filteredInnReachLocationOptions = getFilteredInnReachLocationOptions(innReachLocationOptions, values, index);
+
+              return (
+                <Fragment key={index}>
+                  <b>
+                    {`${formatMessage({ id: 'ui-inn-reach.settings.folio-to-inn-reach-locations.list-title.local-agency-code' })}
+                      : ${localAgency[CODE]}`}
+                  </b>
+                  <TableStyleList
+                    requiredRightCol
+                    fieldArrayName={`${LIBRARIES_TABULAR_LIST}${index}`}
+                    rootClassName={css.tabularList}
+                    leftTitle={<FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.libraries" />}
+                    rightTitle={<FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.inn-reach-locations" />}
+                    leftFieldName={FOLIO_LIBRARY}
+                    rightFieldName={INN_REACH_LOCATIONS}
+                    dataOptions={filteredInnReachLocationOptions}
+                    ariaLabel={<FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.inn-reach-locations" />}
+                    validate={(value, allValues) => validate(value, allValues, index)}
+                  />
+                </Fragment>
+              );
+            })
+            : <TableStyleList
+                fieldArrayName={LOCATIONS_TABULAR_LIST}
+                leftTitle={<FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.locations" />}
+                rightTitle={<FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.inn-reach-locations" />}
+                leftFieldName={FOLIO_LOCATION}
+                rightFieldName={INN_REACH_LOCATIONS}
+                dataOptions={innReachLocationOptions}
+                ariaLabel={<FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.inn-reach-locations" />}
+                validate={validate}
+            />
+        )}
       </form>
     </Pane>
   );
@@ -177,8 +183,8 @@ FolioToInnReachLocationsForm.propTypes = {
   form: PropTypes.object.isRequired,
   formatMessage: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
-  initialValues: PropTypes.object.isRequired,
   innReachLocations: PropTypes.arrayOf(PropTypes.object).isRequired,
+  invalid: PropTypes.bool.isRequired,
   isMappingsPending: PropTypes.bool.isRequired,
   isResetForm: PropTypes.bool.isRequired,
   isShowTabularList: PropTypes.bool.isRequired,
@@ -186,6 +192,7 @@ FolioToInnReachLocationsForm.propTypes = {
   locationsMappingType: PropTypes.string.isRequired,
   mappingType: PropTypes.string.isRequired,
   mappingTypesOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  pristine: PropTypes.bool.isRequired,
   selectedServer: PropTypes.object.isRequired,
   serverLibraryOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
   serverOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -200,5 +207,7 @@ export default stripesFinalForm({
   navigationCheck: true,
   subscription: {
     values: true,
+    pristine: true,
+    invalid: true,
   },
 })(FolioToInnReachLocationsForm);

--- a/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/FolioToInnReachLocationsForm.js
+++ b/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/FolioToInnReachLocationsForm.js
@@ -1,7 +1,6 @@
 import React, {
   useEffect,
   useMemo,
-  Fragment,
 } from 'react';
 import stripesFinalForm from '@folio/stripes/final-form';
 import PropTypes from 'prop-types';
@@ -13,6 +12,7 @@ import {
   PaneFooter,
   Select,
   Selection,
+  Headline,
 } from '@folio/stripes-components';
 import {
   CENTRAL_SERVER_CONFIGURATION_FIELDS,
@@ -22,8 +22,9 @@ import {
   LOCAL_AGENCIES_FIELDS,
 } from '../../../../constants';
 import {
-  getFilteredInnReachLocationOptions,
+  getLocationsForEachTableRow,
   getInnReachLocationOptions,
+  getUniqueLocationsForEachTable,
   validate,
 } from './utils';
 import {
@@ -140,14 +141,18 @@ const FolioToInnReachLocationsForm = ({
         {isShowTabularList && (
           mappingType === librariesMappingType
             ? selectedServer[LOCAL_AGENCIES].map((localAgency, index) => {
-              const filteredInnReachLocationOptions = getFilteredInnReachLocationOptions(innReachLocationOptions, values, index);
+              const filteredInnReachLocationOptions = getUniqueLocationsForEachTable(innReachLocationOptions, values, index);
 
               return (
-                <Fragment key={index}>
-                  <b>
-                    {`${formatMessage({ id: 'ui-inn-reach.settings.folio-to-inn-reach-locations.list-title.local-agency-code' })}
-                      : ${localAgency[CODE]}`}
-                  </b>
+                <section key={index}>
+                  <Headline
+                    tag="h2"
+                    margin="none"
+                    className={css.tabularListTitle}
+                  >
+                    {`${formatMessage({ id: 'ui-inn-reach.settings.folio-to-inn-reach-locations.list-title.local-agency-code' })}:
+                     ${localAgency[CODE]}`}
+                  </Headline>
                   <TableStyleList
                     requiredRightCol
                     fieldArrayName={`${LIBRARIES_TABULAR_LIST}${index}`}
@@ -159,8 +164,9 @@ const FolioToInnReachLocationsForm = ({
                     dataOptions={filteredInnReachLocationOptions}
                     ariaLabel={<FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.inn-reach-locations" />}
                     validate={(value, allValues) => validate(value, allValues, index)}
+                    onProcessDataOptions={getLocationsForEachTableRow}
                   />
-                </Fragment>
+                </section>
               );
             })
             : <TableStyleList
@@ -172,6 +178,7 @@ const FolioToInnReachLocationsForm = ({
                 dataOptions={innReachLocationOptions}
                 ariaLabel={<FormattedMessage id="ui-inn-reach.settings.folio-to-inn-reach-locations.field.inn-reach-locations" />}
                 validate={validate}
+                onProcessDataOptions={getLocationsForEachTableRow}
             />
         )}
       </form>

--- a/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/FolioToInnReachLocationsForm.test.js
+++ b/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/FolioToInnReachLocationsForm.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
+import StripesFinalFormWrapper from '@folio/stripes-final-form/lib/StripesFinalFormWrapper';
 import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';
 import { translationsProperties } from '../../../../../test/jest/helpers';
@@ -25,42 +26,59 @@ const serverOptions = [
   {
     id: '6e2b3e23-8d58-4cd3-985d-b4eb2e9a2ec9',
     label: 'testName2',
-    value: 'testName2'
+    value: 'testName2',
+    localAgencies: [
+      {
+        code: 'fl1g1',
+        folioLibraryIds: ['5d78803e-ca04-4b4a-aeae-2c63b924518b', '05d23bb3-a1a2-40e6-ba85-c8fb9bd38d80'],
+      },
+      {
+        code: 'fl1g2',
+        folioLibraryIds: ['c2549bb4-19c7-4fcc-8b52-39e612fb7dbe'],
+      },
+    ],
   }
 ];
 
 const serverLibraryOptions = [
   NO_VALUE_LIBRARY_OPTION,
   {
-    id: '0939ebc4-cf37-4968-841e-912c0c02eacf',
-    label: 'newLib (QWER)',
-    value: 'newLib',
+    code: 'd2i01',
+    id: '05d23bb3-a1a2-40e6-ba85-c8fb9bd38d80',
+    label: 'D2IR Local 1 (d2i01)',
+    value: 'D2IR Local 1',
   },
   {
-    id: '9e3ccd90-8d64-4c52-8ee8-f09f5d4ebb56',
-    label: 'test library (l)',
-    value: 'test library',
+    code: 'DI',
+    id: '5d78803e-ca04-4b4a-aeae-2c63b924518b',
+    label: 'Datalogisk Institut (DI)',
+    value: 'Datalogisk Institut',
+  },
+  {
+    code: 'E',
+    id: 'c2549bb4-19c7-4fcc-8b52-39e612fb7dbe',
+    label: 'Online (E)',
+    value: 'Online',
   },
 ];
 
 const innReachLocations = [
   {
-    id: '7ab09535-7ba8-40e7-8b14-4c7f6c171820',
-    code: 'assa',
+    id: 'c625c7e0-02c9-4264-a899-d329c2e032c9',
+    code: 'smgen',
+    value: 'smgen',
   },
   {
-    id: 'feafa30d-0b0c-43e3-a283-5344bd0ae5ab',
-    code: 'bbb',
+    id: 'a6742e42-a8a8-4e92-9cf8-885b77ec9236',
+    code: 'wpgen',
+    value: 'wpgen',
   },
-  {
-    id: '7fab623d-1947-4413-b315-eae9ba9bb0c0',
-    code: 'test',
-  }
 ];
 
 const selectedServerMock = {
   id: serverOptions[1].id,
   name: serverOptions[1].label,
+  localAgencies: serverOptions[1].localAgencies,
 };
 
 const mappingTypesOptions = [
@@ -81,10 +99,18 @@ const mappingTypesOptions = [
   }
 ];
 
+const opts = {
+  navigationCheck: true,
+  subscription: {
+    values: true,
+    pristine: true,
+    invalid: true,
+  },
+};
+
 const renderFolioToInnReachLocationsForm = ({
   selectedServer = {},
   mappingType = '',
-  isPristine = true,
   initialValues = {},
   isResetForm = false,
   history = createMemoryHistory(),
@@ -94,19 +120,20 @@ const renderFolioToInnReachLocationsForm = ({
   isMappingsPending = false,
   leftColumnName = FOLIO_LIBRARY,
   isShowTabularList = false,
-  onChangePristineState,
   onChangeFormResetState,
   onChangeMappingType,
   onChangeLibrary,
 } = {}) => {
   return renderWithIntl(
     <Router history={history}>
-      <FolioToInnReachLocationsForm
+      <StripesFinalFormWrapper
+        Form={FolioToInnReachLocationsForm}
+        formOptions={opts}
+        initialValues={initialValues}
         selectedServer={selectedServer}
         mappingType={mappingType}
         serverLibraryOptions={serverLibraryOptions}
         innReachLocations={innReachLocations}
-        isPristine={isPristine}
         serverOptions={serverOptions}
         isMappingsPending={isMappingsPending}
         leftColumnName={leftColumnName}
@@ -115,11 +142,9 @@ const renderFolioToInnReachLocationsForm = ({
         formatMessage={({ id }) => id}
         librariesMappingType="Libraries"
         locationsMappingType="Locations"
-        initialValues={initialValues}
         isResetForm={isResetForm}
         values={values}
         onSubmit={handleSubmit}
-        onChangePristineState={onChangePristineState}
         onChangeFormResetState={onChangeFormResetState}
         onChangeServer={onChangeServer}
         onChangeMappingType={onChangeMappingType}
@@ -132,7 +157,6 @@ const renderFolioToInnReachLocationsForm = ({
 
 describe('FolioToInnReachLocationsForm', () => {
   const onChangeFormResetState = jest.fn();
-  const onChangePristineState = jest.fn();
   const handleSubmit = jest.fn();
   const onChangeServer = jest.fn();
   const onChangeLibrary = jest.fn();
@@ -140,7 +164,6 @@ describe('FolioToInnReachLocationsForm', () => {
 
   const commonProps = {
     onChangeFormResetState,
-    onChangePristineState,
     handleSubmit,
     onChangeServer,
     onChangeLibrary,
@@ -177,23 +200,28 @@ describe('FolioToInnReachLocationsForm', () => {
     it('should be active for the "libraries" mapping type', async () => {
       renderFolioToInnReachLocationsForm({
         ...commonProps,
-        isPristine: false,
         selectedServer: selectedServerMock,
         mappingType: mappingTypesOptions[1].value,
         isShowTabularList: true,
         initialValues: {
-          tabularList: [
+          librariesTabularList0: [
             {
-              [FOLIO_LOCATION]: 'newLib (QWER)',
+              [FOLIO_LOCATION]: 'D2IR Local 1 (d2i01)',
             },
             {
-              [FOLIO_LOCATION]: 'test library (l)',
+              [FOLIO_LOCATION]: 'Datalogisk Institut (DI)',
+            },
+          ],
+          librariesTabularList1: [
+            {
+              [FOLIO_LOCATION]: 'Online (E)',
             },
           ],
         },
       });
-      document.getElementById('option-tabularList[0].innReachLocations-0-2-bbb').click();
-      document.getElementById('option-tabularList[1].innReachLocations-1-3-test').click();
+      document.getElementById('option-librariesTabularList0[0].innReachLocations-0-1-smgen').click();
+      document.getElementById('option-librariesTabularList0[1].innReachLocations-1-1-smgen').click();
+      document.getElementById('option-librariesTabularList1[0].innReachLocations-0-2-wpgen').click();
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
@@ -204,23 +232,22 @@ describe('FolioToInnReachLocationsForm', () => {
       renderFolioToInnReachLocationsForm({
         ...commonProps,
         leftColumnName: FOLIO_LOCATION,
-        isPristine: false,
         selectedServer: selectedServerMock,
         mappingType: mappingTypesOptions[2].value,
         isShowTabularList: true,
         initialValues: {
-          tabularList: [
+          locationsTabularList: [
             {
-              [FOLIO_LOCATION]: 'newLib (QWER)',
+              [FOLIO_LOCATION]: 'D2IR Local 1 (d2i01)',
             },
             {
-              [FOLIO_LOCATION]: 'test library (l)',
+              [FOLIO_LOCATION]: 'Datalogisk Institut (DI)',
             },
           ],
         },
       });
 
-      document.getElementById('option-tabularList[0].innReachLocations-0-2-bbb').click();
+      document.getElementById('option-locationsTabularList[0].innReachLocations-0-1-smgen').click();
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();

--- a/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/utils.js
+++ b/src/settings/components/FolioToInnReachLocations/FolioToInnReachLocationsForm/utils.js
@@ -1,4 +1,7 @@
 import {
+  some,
+} from 'lodash';
+import {
   FOLIO_TO_INN_REACH_LOCATION_FIELDS,
   NO_VALUE_LOCATION_OPTION,
 } from '../../../../constants';
@@ -8,7 +11,8 @@ import {
 
 const {
   INN_REACH_LOCATIONS,
-  TABULAR_LIST,
+  LIBRARIES_TABULAR_LIST,
+  LOCATIONS_TABULAR_LIST,
   FOLIO_LIBRARY,
   FOLIO_LOCATION,
 } = FOLIO_TO_INN_REACH_LOCATION_FIELDS;
@@ -27,8 +31,8 @@ export const getInnReachLocationOptions = (innReachLocations) => {
   }, [NO_VALUE_LOCATION_OPTION]);
 };
 
-export const validate = (value, allValues) => {
-  const tabularList = allValues[TABULAR_LIST];
+export const validate = (value, allValues, index) => {
+  const tabularList = allValues[LOCATIONS_TABULAR_LIST] || allValues[`${LIBRARIES_TABULAR_LIST}${index}`];
   const leftColName = tabularList[0][FOLIO_LIBRARY]
     ? FOLIO_LIBRARY
     : FOLIO_LOCATION;
@@ -40,4 +44,14 @@ export const validate = (value, allValues) => {
 
     return required(value || isSomeFieldFilledIn);
   }
+};
+
+export const getFilteredInnReachLocationOptions = (innReachLocationOptions, values, index) => {
+  return innReachLocationOptions.filter(location => {
+    return !some(values, (tabularList, key) => {
+      return tabularList.some(listItem => {
+        return listItem[INN_REACH_LOCATIONS] === location.value && key !== `${LIBRARIES_TABULAR_LIST}${index}`;
+      });
+    });
+  });
 };

--- a/src/settings/components/common/TableStyleList/TableStyleList.js
+++ b/src/settings/components/common/TableStyleList/TableStyleList.js
@@ -25,19 +25,26 @@ const TableStyleList = ({
   requiredRightCol,
   rootClassName,
   validate,
+  onProcessDataOptions,
 }) => {
-  const getDefaultList = ({ fields }) => fields.map((name, index) => (
-    <DefaultRow
-      key={index}
-      name={name}
-      index={index}
-      leftFieldName={leftFieldName}
-      rightFieldName={rightFieldName}
-      dataOptions={dataOptions}
-      ariaLabel={ariaLabel}
-      validate={validate}
-    />
-  ));
+  const getDefaultList = ({ fields }) => fields.map((name, index) => {
+    const options = onProcessDataOptions
+      ? onProcessDataOptions(fields, index, dataOptions)
+      : dataOptions;
+
+    return (
+      <DefaultRow
+        key={index}
+        name={name}
+        index={index}
+        leftFieldName={leftFieldName}
+        rightFieldName={rightFieldName}
+        dataOptions={options}
+        ariaLabel={ariaLabel}
+        validate={validate}
+      />
+    );
+  });
 
   return (
     <Col
@@ -76,6 +83,7 @@ TableStyleList.propTypes = {
   rightTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   rootClassName: PropTypes.string,
   validate: PropTypes.func,
+  onProcessDataOptions: PropTypes.func,
 };
 
 export default TableStyleList;

--- a/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationEditRoute.test.js
+++ b/src/settings/routes/CentralServersConfigurationRoute/CentralServersConfigurationEditRoute.test.js
@@ -56,7 +56,6 @@ const values = {
       localAgency: 'PERK',
       FOLIOLibraries: [
         {
-          id: 'c3c85d4c-e6fc-4905-bd12-abfa730584e3',
           label: 'Bostock',
           value: 'c3c85d4c-e6fc-4905-bd12-abfa730584e3',
         },
@@ -147,7 +146,6 @@ describe('CentralServersConfigurationEditRoute component', () => {
 
   it('should load central server record on first render', () => {
     renderEditRoute();
-
     expect(CentralServersConfigurationCreateEditContainer.mock.calls[1][0]).toHaveProperty('initialValues', values);
   });
 

--- a/src/settings/routes/CentralServersConfigurationRoute/utils.js
+++ b/src/settings/routes/CentralServersConfigurationRoute/utils.js
@@ -10,7 +10,7 @@ export const getConvertedLocalAgenciesToCreateEdit = (localAgencies = []) => {
     if (localAgency && !isEmpty(FOLIOLibraries)) {
       const localAgencyData = {
         [LOCAL_AGENCIES_FIELDS.CODE]: localAgency,
-        [LOCAL_AGENCIES_FIELDS.FOLIO_LIBRARY_IDs]: FOLIOLibraries.map(library => library.value),
+        [LOCAL_AGENCIES_FIELDS.FOLIO_LIBRARY_IDS]: FOLIOLibraries.map(library => library.value),
       };
 
       if (id) {
@@ -33,7 +33,6 @@ export const getConvertedLocalAgencies = (localAgencies, folioLibraries) => {
 
   return localAgencies.map(({ id, code, folioLibraryIds }) => {
     const FOLIOLibraries = folioLibraryIds.map(libraryId => ({
-      id: libraryId,
       label: folioLibrariesMap.get(libraryId)?.name,
       value: libraryId,
     }));

--- a/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.js
+++ b/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.js
@@ -18,8 +18,10 @@ import {
 } from '../../../hooks';
 import {
   CALLOUT_ERROR_TYPE,
+  CENTRAL_SERVER_CONFIGURATION_FIELDS,
   CENTRAL_SERVERS_LIMITING,
   FOLIO_TO_INN_REACH_LOCATION_FIELDS,
+  LOCAL_AGENCIES_FIELDS,
   NO_VALUE_LIBRARY_OPTION,
   NO_VALUE_OPTION_VALUE,
 } from '../../../constants';
@@ -41,8 +43,17 @@ import {
 } from '../../../utils';
 
 const {
-  TABULAR_LIST,
+  LIBRARIES_TABULAR_LIST,
+  LOCATIONS_TABULAR_LIST,
 } = FOLIO_TO_INN_REACH_LOCATION_FIELDS;
+
+const {
+  LOCAL_AGENCIES,
+} = CENTRAL_SERVER_CONFIGURATION_FIELDS;
+
+const {
+  FOLIO_LIBRARY_IDS,
+} = LOCAL_AGENCIES_FIELDS;
 
 const FolioToInnReachLocationsCreateEditRoute = ({
   resources: {
@@ -86,8 +97,6 @@ const FolioToInnReachLocationsCreateEditRoute = ({
   const [libraryMappings, setLibraryMappings] = useState([]);
   const [locationMappings, setLocationMappings] = useState([]);
   const [isMappingsPending, setIsMappingsPending] = useState(false);
-  const [locationMappingsMap, setLocationMappingsMap] = useState(null);
-  const [librariesMappingsMap, setLibrariesMappingsMap] = useState(null);
 
   const serverOptions = useMemo(() => getCentralServerOptions(servers), [servers]);
   const librariesMappingType = formatMessage({ id: 'ui-inn-reach.settings.folio-to-inn-reach-locations.field-value.libraries' });
@@ -141,8 +150,6 @@ const FolioToInnReachLocationsCreateEditRoute = ({
   const reset = () => {
     setServerLibraries([]);
     setServerLibraryOptions([]);
-    setLibrariesMappingsMap(null);
-    setLocationMappingsMap(null);
     resetCentralServer();
     resetData();
     setMappingType('');
@@ -214,7 +221,7 @@ const FolioToInnReachLocationsCreateEditRoute = ({
           folioLocations,
           tabularListMap: getTabularListMap(record.tabularList),
           innReachLocationsMap: getInnReachLocationsMapCodeFirst(innReachLocations),
-          locationMappingsMap,
+          locationMappingsMap: getLocationMappingsMap(locationMappings),
         }),
       };
 
@@ -239,7 +246,7 @@ const FolioToInnReachLocationsCreateEditRoute = ({
           folioLibraries,
           tabularListMap: getTabularListMap(record.tabularList),
           innReachLocationsMap: getInnReachLocationsMapCodeFirst(innReachLocations),
-          librariesMappingsMap,
+          librariesMappingsMap: getLibrariesMappingsMap(libraryMappings),
         }),
       };
 
@@ -264,43 +271,44 @@ const FolioToInnReachLocationsCreateEditRoute = ({
   useEffect(() => {
     if (!isMappingsPending && mappingType === librariesMappingType) {
       if (isEmpty(libraryMappings)) {
-        setInitialValues({
-          [TABULAR_LIST]: getLeftColumnLibraries(serverLibraries),
-        });
+        const librariesInitialValues = selectedServer[LOCAL_AGENCIES].reduce((accum, localAgency, index) => {
+          accum[`${LIBRARIES_TABULAR_LIST}${index}`] = getLeftColumnLibraries(serverLibraries, localAgency[FOLIO_LIBRARY_IDS]);
+
+          return accum;
+        }, {});
+
+        setInitialValues(librariesInitialValues);
       } else {
-        const libMappingsMap = getLibrariesMappingsMap(libraryMappings);
-
-        setLibrariesMappingsMap(libMappingsMap);
-
-        setInitialValues({
-          [TABULAR_LIST]: getLibrariesTabularList({
-            libMappingsMap,
+        const librariesInitialValues = selectedServer[LOCAL_AGENCIES].reduce((accum, localAgency, index) => {
+          accum[`${LIBRARIES_TABULAR_LIST}${index}`] = getLibrariesTabularList({
+            libMappingsMap: getLibrariesMappingsMap(libraryMappings),
             serverLibraries,
             innReachLocations,
-          }),
-        });
+            folioLibraryIds: localAgency[FOLIO_LIBRARY_IDS],
+          });
+
+          return accum;
+        }, {});
+
+        setInitialValues(librariesInitialValues);
       }
     }
-  }, [libraryMappings, isMappingsPending]);
+  }, [libraryMappings, isMappingsPending, selectedServer]);
 
   useEffect(() => {
     if (!isMappingsPending && mappingType === locationsMappingType) {
       if (isEmpty(locationMappings)) {
         setInitialValues({
-          [TABULAR_LIST]: getLeftColumnLocations({
+          [LOCATIONS_TABULAR_LIST]: getLeftColumnLocations({
             selectedLibraryId,
             folioLocations,
             folioLibraries,
           }),
         });
       } else {
-        const locMappingsMap = getLocationMappingsMap(locationMappings);
-
-        setLocationMappingsMap(locMappingsMap);
-
         setInitialValues({
-          [TABULAR_LIST]: getTabularListForLocations({
-            locMappingsMap,
+          [LOCATIONS_TABULAR_LIST]: getTabularListForLocations({
+            locMappingsMap: getLocationMappingsMap(locationMappings),
             selectedLibraryId,
             folioLocations,
             innReachLocations,

--- a/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.js
+++ b/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.js
@@ -219,7 +219,7 @@ const FolioToInnReachLocationsCreateEditRoute = ({
       finalRecord = {
         locationMappings: getFinalLocationMappings({
           folioLocations,
-          tabularListMap: getTabularListMap(record.tabularList),
+          tabularListMap: getTabularListMap(record),
           innReachLocationsMap: getInnReachLocationsMapCodeFirst(innReachLocations),
           locationMappingsMap: getLocationMappingsMap(locationMappings),
         }),
@@ -244,7 +244,7 @@ const FolioToInnReachLocationsCreateEditRoute = ({
       finalRecord = {
         libraryMappings: getFinalLibraryMappings({
           folioLibraries,
-          tabularListMap: getTabularListMap(record.tabularList),
+          tabularListMap: getTabularListMap(record),
           innReachLocationsMap: getInnReachLocationsMapCodeFirst(innReachLocations),
           librariesMappingsMap: getLibrariesMappingsMap(libraryMappings),
         }),

--- a/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.test.js
+++ b/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.test.js
@@ -34,7 +34,7 @@ const servers = [
       },
       {
         code: '4ffeg',
-        folioLibraryIds: ['0939ebc4-cf37-4968-841e-912c0c02eacf', '9e3ccd90-8d64-4c52-8ee8-f09f5d4ebb56'],
+        folioLibraryIds: ['c2549bb4-19c7-4fcc-8b52-39e612fb7dbe'],
         id: '5ffa6f06-8f09-4f32-991d-ed78b70f3e1e',
       }
     ],
@@ -93,6 +93,12 @@ const loclibs = [
     code: 'l',
     name: 'test library',
   },
+  {
+    id: 'c2549bb4-19c7-4fcc-8b52-39e612fb7dbe',
+    campusId: '470ff1dd-937a-4195-bf9e-06bcfcd135df',
+    code: 'E',
+    name: 'Online',
+  },
 ];
 
 const innReachLocations = [
@@ -115,7 +121,7 @@ const innReachLocations = [
 ];
 
 const recordForLocationMappings = {
-  tabularList: [
+  locationsTabularList: [
     {
       folioLocation: 'folioName5 (code5)',
       innReachLocations: 'test',
@@ -129,7 +135,7 @@ const recordForLocationMappings = {
 };
 
 const recordForLibrariesMappings = {
-  tabularList: [
+  librariesTabularList0: [
     {
       folioLibrary: 'newLib (QWER)',
       innReachLocations: 'test',
@@ -138,6 +144,12 @@ const recordForLibrariesMappings = {
     {
       folioLibrary: 'test library (l)',
       code: 'l',
+    },
+  ],
+  librariesTabularList1: [
+    {
+      folioLibrary: 'Online (E)',
+      code: 'E',
     },
   ],
 };
@@ -273,7 +285,13 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
           label: 'test library (l)',
           value: 'test library',
           code: 'l',
-        }
+        },
+        {
+          id: 'c2549bb4-19c7-4fcc-8b52-39e612fb7dbe',
+          label: 'Online (E)',
+          value: 'Online',
+          code: 'E',
+        },
       ]);
     });
   });
@@ -284,16 +302,22 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
       act(() => { FolioToInnReachLocationsForm.mock.calls[0][0].onChangeServer(servers[0].name); });
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[1][0].onChangeMappingType('Libraries'); });
       expect(FolioToInnReachLocationsForm.mock.calls[5][0].initialValues).toEqual({
-        tabularList: [
+        librariesTabularList0: [
           {
-            folioLibrary: 'newLib (QWER)',
-            code: 'QWER',
+            'code': 'QWER',
+            'folioLibrary': 'newLib (QWER)',
           },
           {
-            folioLibrary: 'test library (l)',
-            code: 'l',
-          }
-        ]
+            'code': 'l',
+            'folioLibrary': 'test library (l)',
+          },
+        ],
+        librariesTabularList1: [
+          {
+            'code': 'E',
+            'folioLibrary': 'Online (E)',
+          },
+        ],
       });
     });
 
@@ -322,7 +346,7 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[0][0].onChangeMappingType('Locations'); });
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[1][0].onChangeLibrary(loclibs[1].name); });
       expect(FolioToInnReachLocationsForm.mock.calls[5][0].initialValues).toEqual({
-        tabularList: [
+        locationsTabularList: [
           {
             folioLocation: 'folioName5 (code5)',
             code: 'code5',
@@ -363,7 +387,8 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
 
     it('should make GET request for library mappings', async () => {
       renderFolioToInnReachLocationsCreateEditRoute({ history });
-      await act(async () => { await FolioToInnReachLocationsForm.mock.calls[0][0].onChangeMappingType('Libraries'); });
+      act(() => { FolioToInnReachLocationsForm.mock.calls[0][0].onChangeServer(servers[0].name); });
+      await act(async () => { await FolioToInnReachLocationsForm.mock.calls[1][0].onChangeMappingType('Libraries'); });
       expect(mutatorMock.libraryMappings.GET).toHaveBeenCalled();
     });
   });
@@ -407,8 +432,10 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
 
     it('should make PUT for libraryMappings', async () => {
       renderFolioToInnReachLocationsCreateEditRoute({ history });
-      act(() => { FolioToInnReachLocationsForm.mock.calls[0][0].onChangeMappingType('Libraries'); });
-      await act(async () => { await FolioToInnReachLocationsForm.mock.calls[1][0].onSubmit(recordForLibrariesMappings); });
+      act(() => { FolioToInnReachLocationsForm.mock.calls[0][0].onChangeServer(servers[0].name); });
+      act(() => { FolioToInnReachLocationsForm.mock.calls[1][0].onChangeMappingType('Libraries'); });
+
+      await act(async () => { await FolioToInnReachLocationsForm.mock.calls[2][0].onSubmit(recordForLibrariesMappings); });
       expect(mutatorMock.libraryMappings.PUT).toHaveBeenCalledWith({
         libraryMappings: [
           {

--- a/src/settings/routes/FolioToInnReachLocations/utils.js
+++ b/src/settings/routes/FolioToInnReachLocations/utils.js
@@ -179,11 +179,23 @@ export const getLeftColumnLocations = ({
   }, []);
 };
 
-export const getLeftColumnLibraries = (serverLibraries) => {
-  return serverLibraries.map(({ label, code }) => ({
-    [FOLIO_LIBRARY]: label,
-    [CODE]: code,
-  }));
+const getFolioLibraryIdsSet = (folioLibraryIds) => {
+  return folioLibraryIds.reduce((accum, libId) => {
+    accum.add(libId);
+
+    return accum;
+  }, new Set());
+};
+
+export const getLeftColumnLibraries = (serverLibraries, folioLibraryIds) => {
+  const folioLibraryIdsSet = getFolioLibraryIdsSet(folioLibraryIds);
+
+  return serverLibraries
+    .filter(({ id }) => folioLibraryIdsSet.has(id))
+    .map(({ label, code }) => ({
+      [FOLIO_LIBRARY]: label,
+      [CODE]: code,
+    }));
 };
 
 export const getTabularListForLocations = ({
@@ -221,24 +233,28 @@ export const getLibrariesTabularList = ({
   serverLibraries,
   libMappingsMap,
   innReachLocations,
+  folioLibraryIds,
 }) => {
   const innReachLocationsMap = getInnReachLocationsMap(innReachLocations);
+  const folioLibraryIdsSet = getFolioLibraryIdsSet(folioLibraryIds);
 
-  return serverLibraries.map(({ id, label, code }) => {
-    const option = {
-      [FOLIO_LIBRARY]: label,
-      [CODE]: code,
-    };
-    const isCodeSelected = libMappingsMap.has(id);
+  return serverLibraries
+    .filter(({ id }) => folioLibraryIdsSet.has(id))
+    .map(({ id, label, code }) => {
+      const option = {
+        [FOLIO_LIBRARY]: label,
+        [CODE]: code,
+      };
+      const isCodeSelected = libMappingsMap.has(id);
 
-    if (isCodeSelected) {
-      const innReachLocationId = libMappingsMap.get(id).innReachLocationId;
+      if (isCodeSelected) {
+        const innReachLocationId = libMappingsMap.get(id).innReachLocationId;
 
-      option[INN_REACH_LOCATIONS] = innReachLocationsMap.get(innReachLocationId);
-    }
+        option[INN_REACH_LOCATIONS] = innReachLocationsMap.get(innReachLocationId);
+      }
 
-    return option;
-  });
+      return option;
+    });
 };
 
 export const getTabularListMap = (tabularList) => {

--- a/src/settings/routes/FolioToInnReachLocations/utils.js
+++ b/src/settings/routes/FolioToInnReachLocations/utils.js
@@ -1,4 +1,7 @@
 import {
+  flatMap,
+} from 'lodash';
+import {
   FOLIO_TO_INN_REACH_LOCATION_FIELDS,
 } from '../../../constants';
 
@@ -257,10 +260,11 @@ export const getLibrariesTabularList = ({
     });
 };
 
-export const getTabularListMap = (tabularList) => {
+export const getTabularListMap = (record) => {
   const tabularListMap = new Map();
+  const tabularLists = flatMap(record, tabularList => tabularList);
 
-  tabularList.forEach(row => {
+  tabularLists.forEach(row => {
     tabularListMap.set(row[CODE], row[INN_REACH_LOCATIONS]);
   });
 

--- a/translations/ui-inn-reach/en.json
+++ b/translations/ui-inn-reach/en.json
@@ -140,6 +140,7 @@
   "settings.folio-to-inn-reach-locations.create-edit.connectionProblem.put": "Unable to updated data due to a module error. Please try again. If a problem persists please contact your system administrator",
   "settings.folio-to-inn-reach-locations.create-edit.create.success": "FOLIO to INN-Reach locations settings created successfully",
   "settings.folio-to-inn-reach-locations.create-edit.update.success": "FOLIO to INN-Reach locations settings updated successfully",
+  "settings.folio-to-inn-reach-locations.list-title.local-agency-code": "Local agency code",
 
   "settings.contribution-options.status.awaiting-delivery": "Awaiting delivery",
   "settings.contribution-options.status.claimed-returned": "Claimed returned",


### PR DESCRIPTION
## Purpose
Update the FOLIO to INN-Reach locations settings screen to group libraries by agency code AND prevent INN-Reach locations from being assigned to libraries or locations in more than one agency.
## Refs
[UIINREACH-100](https://issues.folio.org/browse/UIINREACH-100)
## Screenshots
![image](https://user-images.githubusercontent.com/77053927/152367829-0362632a-6d31-47ee-a9d3-d75f290a28bf.png)
![image](https://user-images.githubusercontent.com/77053927/152367904-24b6b488-4404-4eee-8dc8-9ef8189a58ce.png)
