### PR TITLE
UIINREACH-147: INN-Reach Staff Interface: Receive Shipped Item Action: Barcode Augmented Message

### DIFF
--- a/src/components/common/HoldModal/HoldModal.js
+++ b/src/components/common/HoldModal/HoldModal.js
@@ -86,9 +86,9 @@ HoldModal.propTypes = {
   intl: PropTypes.object.isRequired,
   stripes: stripesShape.isRequired,
   onClose: PropTypes.func.isRequired,
-  onFocusBarcodeField: PropTypes.func.isRequired,
   onGetSlipTmpl: PropTypes.func.isRequired,
   checkinData: PropTypes.object,
+  onFocusBarcodeField: PropTypes.func,
 };
 
 export default HoldModal;

--- a/src/components/common/InTransitModal/InTransitModal.js
+++ b/src/components/common/InTransitModal/InTransitModal.js
@@ -67,9 +67,9 @@ InTransitModal.propTypes = {
   intl: PropTypes.object.isRequired,
   stripes: stripesShape.isRequired,
   onClose: PropTypes.func.isRequired,
-  onFocusBarcodeField: PropTypes.func.isRequired,
   onGetSlipTmpl: PropTypes.func.isRequired,
   checkinData: PropTypes.object,
+  onFocusBarcodeField: PropTypes.func,
 };
 
 export default InTransitModal;

--- a/src/components/transaction/TransactionDetails/TransactionDetailContainer.js
+++ b/src/components/transaction/TransactionDetails/TransactionDetailContainer.js
@@ -103,12 +103,16 @@ const TransactionDetailContainer = ({
 
   const fetchReceiveItem = () => {
     mutator.receiveItem.POST({})
-      .then(() => {
+      .then(response => {
+        onSetCheckinData(response);
         onUpdateTransactionList();
         showCallout({
           message: <FormattedMessage id="ui-inn-reach.receive-item.callout.success.post.receive-item" />,
         });
+
+        return response;
       })
+      .then(onProcessModals)
       .catch(() => {
         showCallout({
           type: CALLOUT_ERROR_TYPE,

--- a/src/components/transaction/TransactionDetails/TransactionDetailContainer.test.js
+++ b/src/components/transaction/TransactionDetails/TransactionDetailContainer.test.js
@@ -72,6 +72,16 @@ const resourcesMock = {
   },
 };
 
+const receiveItemMock = {
+  barcodeAugmented: true,
+  folioCheckIn: {
+    inHouseUse: false,
+    item: {},
+    staffSlipContext: {},
+    transaction: {},
+  },
+};
+
 const mutatorMock = {
   servicePointId: {
     replace: jest.fn(),
@@ -86,7 +96,7 @@ const mutatorMock = {
     POST: jest.fn(() => Promise.resolve(receiveUnshippedItemMock)),
   },
   receiveItem: {
-    POST: jest.fn(() => Promise.resolve()),
+    POST: jest.fn(() => Promise.resolve(receiveItemMock)),
   },
 };
 
@@ -236,6 +246,14 @@ describe('TransactionDetailContainer', () => {
 
     it('should update the transaction list', () => {
       expect(onUpdateTransactionList).toHaveBeenCalled();
+    });
+
+    it('should pass the "receive item" data', () => {
+      expect(onSetCheckinData).toHaveBeenLastCalledWith(receiveItemMock);
+    });
+
+    it('should process the response for modals', () => {
+      expect(onProcessModals).toHaveBeenLastCalledWith(receiveItemMock);
     });
   });
 });

--- a/src/components/transaction/TransactionDetails/components/ActionMenu/ActionMenu.test.js
+++ b/src/components/transaction/TransactionDetails/components/ActionMenu/ActionMenu.test.js
@@ -17,6 +17,7 @@ const renderActionMenu = ({
       onToggle={jest.fn()}
       onReceiveUnshippedItem={jest.fn()}
       onReceiveItem={jest.fn()}
+      onCheckoutBorrowingSite={jest.fn()}
     />,
     translationsProperties,
   );

--- a/src/hooks/useList.js
+++ b/src/hooks/useList.js
@@ -2,6 +2,7 @@ import {
   useState,
   useCallback,
   useEffect,
+  useRef,
 } from 'react';
 import { useLocation } from 'react-router-dom';
 import queryString from 'query-string';
@@ -25,8 +26,8 @@ const useList = (isLoadingRightAway, queryLoadRecords, loadRecordsCB, resultCoun
   const location = useLocation();
   const [records, setRecords] = useState([]);
   const [recordsCount, setRecordsCount] = useState(0);
-  const [recordsOffset, setRecordsOffset] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const recordsOffsetRef = useRef(0);
 
   const loadRecords = useCallback((offset, updateList) => {
     setIsLoading(true);
@@ -47,21 +48,18 @@ const useList = (isLoadingRightAway, queryLoadRecords, loadRecordsCB, resultCoun
   }, [isLoadingRightAway, loadRecordsCB, location.search, queryLoadRecords]);
 
   const onNeedMoreData = () => {
-    const newOffset = recordsOffset + resultCountIncrement;
-
-    loadRecords(newOffset)
-      .then(() => {
-        setRecordsOffset(newOffset);
-      });
+    recordsOffsetRef.current += resultCountIncrement;
+    loadRecords(recordsOffsetRef.current);
   };
 
   const onUpdateList = () => {
-    loadRecords(recordsOffset, true);
+    recordsOffsetRef.current = 0;
+    loadRecords(0, true);
   };
 
   const refreshList = useCallback(() => {
     setRecords([]);
-    setRecordsOffset(0);
+    recordsOffsetRef.current = 0;
     loadRecords(0);
   }, [loadRecords]);
 

--- a/src/hooks/useList.test.js
+++ b/src/hooks/useList.test.js
@@ -55,8 +55,10 @@ describe('useList hook', () => {
       await act(async () => { onUpdateList(); });
     });
 
-    it('should fetch records ', () => {
-      expect(queryLoadRecords).toHaveBeenCalled();
+    it('should fetch records with an offset equal to 0', () => {
+      const offset = 0;
+
+      expect(queryLoadRecords).toHaveBeenCalledWith(offset, true);
     });
 
     it('should not call loadRecordsCB callback', () => {
@@ -77,6 +79,14 @@ describe('useList hook', () => {
 
     it('should call loadRecordsCB callback', () => {
       expect(loadRecordsCB).toHaveBeenCalled();
+    });
+
+    it('should increment the offset by 100', async () => {
+      const { onNeedMoreData } = result.current;
+
+      expect(queryLoadRecords).toHaveBeenCalledWith(100, true);
+      await act(async () => { onNeedMoreData(); });
+      expect(queryLoadRecords).toHaveBeenCalledWith(200, true);
     });
   });
 });


### PR DESCRIPTION
# Purpose
Show the `The barcode for this item already exists in FOLIO` and `In transit` or `Awaiting pickup` modals, when the barcode is augmented.
# Fixed
useList hook: when scrolling fast, transaction requests can be executed with the same offset. Hence the transactions with repetitions.
# Refs
[UIINREACH-147](https://issues.folio.org/browse/UIINREACH-147)
# Screenshots
![image](https://user-images.githubusercontent.com/77053927/154309268-b35c228f-579b-4fbe-ae76-18c1741f40ce.png)
![image](https://user-images.githubusercontent.com/77053927/154309332-7d290971-3f14-41cc-a23a-884f33ea9470.png)