### PR TITLE
UIINREACH-138: Unable to specify strip fields and subfields if 'Modify MARC 001 field for contributed records' is not selected

### DIFF
--- a/src/settings/components/BibTransformationOptions/BibTransformationOptionsForm/BibTransformationOptionsForm.js
+++ b/src/settings/components/BibTransformationOptions/BibTransformationOptionsForm/BibTransformationOptionsForm.js
@@ -64,13 +64,12 @@ const BibTransformationOptionsForm = ({
 
   useEffect(() => {
     const tabularList = values[MODIFIED_FIELDS_FOR_CONTRIBUTED_RECORDS];
+    const isCreatingNewConfig = isEqual(
+      initialValues[MODIFIED_FIELDS_FOR_CONTRIBUTED_RECORDS],
+      DEFAULT_INITIAL_VALUES[MODIFIED_FIELDS_FOR_CONTRIBUTED_RECORDS]
+    );
 
     if (isConfigActive) {
-      const isCreatingNewConfig = isEqual(
-        initialValues[MODIFIED_FIELDS_FOR_CONTRIBUTED_RECORDS],
-        DEFAULT_INITIAL_VALUES[MODIFIED_FIELDS_FOR_CONTRIBUTED_RECORDS]
-      );
-
       if (isCreatingNewConfig) {
         const isSomeIdentifierTypeFilledIn = tabularList.some(row => row[RESOURCE_IDENTIFIER_TYPE_ID]);
 
@@ -80,11 +79,22 @@ const BibTransformationOptionsForm = ({
       } else {
         setCanSave(false);
       }
-    } else {
-      form.reset();
-      setCanSave(false);
+
+      return;
     }
-  }, [values, isConfigActive]);
+
+    if (!isConfigActive) {
+      if (!isCreatingNewConfig) {
+        if (pristine) {
+          setCanSave(false);
+        } else {
+          setCanSave(true);
+        }
+      } else {
+        setCanSave(false);
+      }
+    }
+  }, [values, pristine, isConfigActive]);
 
   const getFooter = () => {
     const saveButton = (
@@ -125,7 +135,7 @@ const BibTransformationOptionsForm = ({
               className={isConfigActive ? css.mbSm : css.mbMd}
               checked={isConfigActive}
               label={<FormattedMessage id="ui-inn-reach.settings.bib-transformation.field.modify-MARC" />}
-              onChange={onChangeConfigState}
+              onChange={onChangeConfigState(form)}
             />
             {isConfigActive &&
               <TabularList

--- a/src/settings/components/BibTransformationOptions/BibTransformationOptionsForm/BibTransformationOptionsForm.test.js
+++ b/src/settings/components/BibTransformationOptions/BibTransformationOptionsForm/BibTransformationOptionsForm.test.js
@@ -98,7 +98,7 @@ describe('BibTransformationOptionsForm', () => {
   });
 
   describe('save button condition', () => {
-    it('should be enabled 1', () => {
+    it('should be enabled when at least one "Identifier type" is selected', () => {
       const { getByRole } = renderBibTransformationOptionsForm({
         ...commonProps,
         isConfigActive: true,
@@ -109,7 +109,7 @@ describe('BibTransformationOptionsForm', () => {
       expect(getByRole('button', { name: 'Save' })).toBeEnabled();
     });
 
-    it('should be enabled 2', () => {
+    it('should be enabled when modifying an existing config', () => {
       const { getByRole } = renderBibTransformationOptionsForm({
         ...commonProps,
         isConfigActive: true,
@@ -126,7 +126,24 @@ describe('BibTransformationOptionsForm', () => {
       expect(getByRole('button', { name: 'Save' })).toBeEnabled();
     });
 
-    it('should be disabled 1', () => {
+    it('should be enabled when the config exists and is closed', () => {
+      const { getByRole } = renderBibTransformationOptionsForm({
+        ...commonProps,
+        isConfigActive: false,
+        initialValues: {
+          [MODIFIED_FIELDS_FOR_CONTRIBUTED_RECORDS]: [
+            {
+              [RESOURCE_IDENTIFIER_TYPE_ID]: 'd09901a7-1407-42d5-a680-e4d83fe93c5d',
+            },
+          ],
+        },
+      });
+
+      userEvent.type(getByRole('textbox', { name: 'Strip fields and subfields' }), '123');
+      expect(getByRole('button', { name: 'Save' })).toBeEnabled();
+    });
+
+    it('should be disabled when fields are pristine', () => {
       const { getByRole } = renderBibTransformationOptionsForm({
         ...commonProps,
         isConfigActive: true,
@@ -146,7 +163,7 @@ describe('BibTransformationOptionsForm', () => {
       expect(getByRole('button', { name: 'Save' })).toBeDisabled();
     });
 
-    it('should be disabled 2', () => {
+    it('should be disabled when there is no change', () => {
       const { getByRole } = renderBibTransformationOptionsForm({
         ...commonProps,
         isConfigActive: false,
@@ -160,6 +177,17 @@ describe('BibTransformationOptionsForm', () => {
         },
       });
 
+      expect(getByRole('button', { name: 'Save' })).toBeDisabled();
+    });
+
+    it('should be disabled when the config does not exist and is closed, but "Strip fields and subfields" field have changes', () => {
+      const { getByRole } = renderBibTransformationOptionsForm({
+        ...commonProps,
+        isConfigActive: false,
+        initialValues: DEFAULT_INITIAL_VALUES,
+      });
+
+      userEvent.type(getByRole('textbox', { name: 'Strip fields and subfields' }), '123');
       expect(getByRole('button', { name: 'Save' })).toBeDisabled();
     });
   });

--- a/src/settings/routes/BibTransformationOptions/BibTransformationOptionsCreateEditRoute.js
+++ b/src/settings/routes/BibTransformationOptions/BibTransformationOptionsCreateEditRoute.js
@@ -31,6 +31,7 @@ import {
 
 const {
   CONFIG_IS_ACTIVE,
+  MODIFIED_FIELDS_FOR_CONTRIBUTED_RECORDS,
 } = BIB_TRANSFORMATION_FIELDS;
 
 const BibTransformationOptionsCreateEditRoute = ({
@@ -109,8 +110,14 @@ const BibTransformationOptionsCreateEditRoute = ({
       });
   };
 
-  const handleChangeConfigState = (event) => {
-    setIsConfigActive(event.target.checked);
+  const handleChangeConfigState = (form) => (event) => {
+    const isChecked = event.target.checked;
+
+    if (!isChecked) {
+      form.change(MODIFIED_FIELDS_FOR_CONTRIBUTED_RECORDS, initialValues[MODIFIED_FIELDS_FOR_CONTRIBUTED_RECORDS]);
+    }
+
+    setIsConfigActive(isChecked);
   };
 
   useEffect(() => {

--- a/src/settings/routes/BibTransformationOptions/BibTransformationOptionsCreateEditRoute.test.js
+++ b/src/settings/routes/BibTransformationOptions/BibTransformationOptionsCreateEditRoute.test.js
@@ -178,8 +178,21 @@ describe('BibTransformationOptionsCreateEditRoute component', () => {
   });
 
   describe('handleChangeConfigState', () => {
-    renderBibTransformationOptionsCreateEditRoute();
-    act(() => { BibTransformationOptionsForm.mock.calls[0][0].onChangeConfigState({ target: { checked: true } }); });
-    expect(BibTransformationOptionsForm.mock.calls[1][0].isConfigActive).toBeTruthy();
+    const form = { change: jest.fn() };
+
+    it('should display the tabular list', () => {
+      renderBibTransformationOptionsCreateEditRoute();
+      act(() => { BibTransformationOptionsForm.mock.calls[0][0].onChangeConfigState(form)({ target: { checked: true } }); });
+      expect(BibTransformationOptionsForm.mock.calls[1][0].isConfigActive).toBeTruthy();
+    });
+
+    it('should make initial state for tabular list', () => {
+      renderBibTransformationOptionsCreateEditRoute();
+      act(() => { BibTransformationOptionsForm.mock.calls[0][0].onChangeConfigState(form)({ target: { checked: false } }); });
+      expect(form.change).toHaveBeenLastCalledWith(
+        'modifiedFieldsForContributedRecords',
+        [{ resourceIdentifierTypeId: undefined }]
+      );
+    });
   });
 });


### PR DESCRIPTION
## Purpose
Fix not being to specify strip fields and subfields unless "Modify MARC 001 field for contributed records" is selected.

## Ref
[UIINREACH-138](https://issues.folio.org/browse/UIINREACH-138)

## Screenshots
![image](https://user-images.githubusercontent.com/77053927/155001362-a380a65d-76ae-47cb-98dd-2b151bc78fb2.png)

