### PR TITLE
UIINREACH-160: Replace react-hot-loader - unmaintained, security (CVE-2021-44906)

### DIFF
--- a/src/settings/routes/AgencyToFolioLocations/index.js
+++ b/src/settings/routes/AgencyToFolioLocations/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ AgencyToFolioLocationsRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(AgencyToFolioLocationsRoute);
+export default AgencyToFolioLocationsRoute;

--- a/src/settings/routes/BibTransformationOptions/index.js
+++ b/src/settings/routes/BibTransformationOptions/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ BibTransformationOptionsRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(BibTransformationOptionsRoute);
+export default BibTransformationOptionsRoute;

--- a/src/settings/routes/CentralItemTypeRoute/index.js
+++ b/src/settings/routes/CentralItemTypeRoute/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ CentralItemTypeRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(CentralItemTypeRoute);
+export default CentralItemTypeRoute;

--- a/src/settings/routes/CentralPatronTypeRoute/index.js
+++ b/src/settings/routes/CentralPatronTypeRoute/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ CentralPatronTypeRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(CentralPatronTypeRoute);
+export default CentralPatronTypeRoute;

--- a/src/settings/routes/CentralServersConfigurationRoute/index.js
+++ b/src/settings/routes/CentralServersConfigurationRoute/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -47,4 +46,4 @@ CentralServersConfigurationRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(CentralServersConfigurationRoute);
+export default CentralServersConfigurationRoute;

--- a/src/settings/routes/ContributionCriteriaRoute/index.js
+++ b/src/settings/routes/ContributionCriteriaRoute/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ ContributionCriteriaRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(ContributionCriteriaRoute);
+export default ContributionCriteriaRoute;

--- a/src/settings/routes/ContributionOptionsRoute/index.js
+++ b/src/settings/routes/ContributionOptionsRoute/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ ContributionOptionsRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(ContributionOptionsRoute);
+export default ContributionOptionsRoute;

--- a/src/settings/routes/FolioCirculationUserRoute/index.js
+++ b/src/settings/routes/FolioCirculationUserRoute/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ FolioCirculationUserRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(FolioCirculationUserRoute);
+export default FolioCirculationUserRoute;

--- a/src/settings/routes/FolioToInnReachLocations/index.js
+++ b/src/settings/routes/FolioToInnReachLocations/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ FolioToInnReachLocationsRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(FolioToInnReachLocationsRoute);
+export default FolioToInnReachLocationsRoute;

--- a/src/settings/routes/InnReachRecallUserRoute/index.js
+++ b/src/settings/routes/InnReachRecallUserRoute/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ InnReachRecallUserRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(InnReachRecallUserRoute);
+export default InnReachRecallUserRoute;

--- a/src/settings/routes/ManageContributionRoute/index.js
+++ b/src/settings/routes/ManageContributionRoute/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ ManageContributionRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(ManageContributionRoute);
+export default ManageContributionRoute;

--- a/src/settings/routes/MaterialTypeRoute/index.js
+++ b/src/settings/routes/MaterialTypeRoute/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ MaterialTypeRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(MaterialTypeRoute);
+export default MaterialTypeRoute;

--- a/src/settings/routes/PatronAgency/index.js
+++ b/src/settings/routes/PatronAgency/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ PatronAgencyRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(PatronAgencyRoute);
+export default PatronAgencyRoute;

--- a/src/settings/routes/VisiblePatronIdRoute/index.js
+++ b/src/settings/routes/VisiblePatronIdRoute/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { hot } from 'react-hot-loader';
 
 import {
   Route,
@@ -26,4 +25,4 @@ VisiblePatronIdRoute.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
 };
 
-export default hot(module)(VisiblePatronIdRoute);
+export default VisiblePatronIdRoute;


### PR DESCRIPTION
## Purpose:
react-hot-loader should be replaced because it is no longer maintained and has security issues.