### PR TITLE
UIINREACH-171: Check out to borrowing sites result list loan due date information displays the loan date, not the due date

### DIFF
--- a/src/components/CheckOutBorrowingSite/components/ListCheckOutItems/ListCheckOutItems.js
+++ b/src/components/CheckOutBorrowingSite/components/ListCheckOutItems/ListCheckOutItems.js
@@ -78,8 +78,8 @@ const ListCheckOutItems = ({
     [BARCODE]: loan => loan[ITEM]?.[BARCODE],
     [TITLE]: loan => loan[ITEM]?.[TITLE],
     [LOAN_POLICY]: loan => loan[LOAN_POLICY]?.[LOAN_POLICY_NAME],
-    [DUE_DATE]: loan => <FormattedDate value={loan[ITEM]?.[DUE_DATE]} />,
-    [TIME]: loan => <FormattedTime value={loan[ITEM]?.[TIME]} />,
+    [DUE_DATE]: loan => <FormattedDate value={loan[DUE_DATE]} />,
+    [TIME]: loan => <FormattedTime value={loan[TIME]} />,
     [LOCATION]: loan => loan[ITEM]?.[LOCATION]?.[LOCATION_NAME],
     [ACTIONS]: (loan) => (
       <ItemActions

--- a/src/components/CheckOutBorrowingSite/components/ListCheckOutItems/ListCheckOutItems.test.js
+++ b/src/components/CheckOutBorrowingSite/components/ListCheckOutItems/ListCheckOutItems.test.js
@@ -1,0 +1,90 @@
+import { screen } from '@testing-library/react';
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+import ListCheckOutItems from './ListCheckOutItems';
+import {
+  ItemActions,
+} from './components';
+import { translationsProperties } from '../../../../../test/jest/helpers';
+
+jest.mock('./components', () => ({
+  ItemActions: jest.fn(() => <div>ItemActions</div>),
+}));
+
+const scannedItemsMock = [
+  {
+    item: {
+      title: 'God Emperor of Dune: Sianoq!',
+      barcode: '5465657801',
+      location: { name: 'location name' },
+    },
+    loanDate: '2019-08-24T14:15:22Z',
+    dueDate: '2019-08-24T14:15:22Z',
+    loanPolicy: { name: 'loan policy name' },
+  },
+];
+
+const intlMock = {
+  formatNumber: jest.fn(),
+  formatMessage: jest.fn(),
+};
+
+const renderListCheckOutItems = ({
+  scannedItems = scannedItemsMock,
+} = {}) => {
+  return renderWithIntl(
+    <ListCheckOutItems
+      scannedItems={scannedItems}
+      intl={intlMock}
+    />,
+    translationsProperties,
+  );
+};
+
+describe('ListCheckOutItems', () => {
+  let commonProps;
+
+  beforeEach(() => {
+    ItemActions.mockClear();
+  });
+
+  it('should be rendered', () => {
+    const { container } = renderListCheckOutItems(commonProps);
+
+    expect(container).toBeVisible();
+  });
+
+  it('should display barcode', () => {
+    renderListCheckOutItems(commonProps);
+    expect(screen.getByText(scannedItemsMock[0].item.barcode)).toBeVisible();
+  });
+
+  it('should display title', () => {
+    renderListCheckOutItems(commonProps);
+    expect(screen.getByText(scannedItemsMock[0].item.title)).toBeVisible();
+  });
+
+  it('should display the loan policy', () => {
+    renderListCheckOutItems(commonProps);
+    expect(screen.getByText(scannedItemsMock[0].loanPolicy.name)).toBeVisible();
+  });
+
+  it('should display the due date', () => {
+    renderListCheckOutItems(commonProps);
+    expect(screen.getByText('8/24/2019')).toBeVisible();
+  });
+
+  it('should display the loan date', () => {
+    renderListCheckOutItems(commonProps);
+    expect(screen.getByText('2:15 PM')).toBeVisible();
+  });
+
+  it('should display the location', () => {
+    renderListCheckOutItems(commonProps);
+    expect(screen.getByText(scannedItemsMock[0].item.location.name)).toBeVisible();
+  });
+
+  it('should display the item actions', () => {
+    renderListCheckOutItems(commonProps);
+    expect(screen.getByText('ItemActions')).toBeVisible();
+  });
+});

--- a/src/components/ReceiveShippedItem/components/CheckIn/components/ListCheckInItems/ListCheckInItems.js
+++ b/src/components/ReceiveShippedItem/components/CheckIn/components/ListCheckInItems/ListCheckInItems.js
@@ -54,7 +54,7 @@ const columnWidths = {
   [BARCODE]: { max: 200 },
   [TITLE]: { max: 350 },
   [PICK_UP_LOCATION]: { max: 500 },
-  [ACTIONS]: { max: 50 },
+  [ACTIONS]: { max: 100 },
 };
 
 const ListCheckInItems = ({


### PR DESCRIPTION
# Purpose
Fix the display of the `due date` and `time` column values.
# Ref
[UIINREACH-171](https://issues.folio.org/browse/UIINREACH-171)