### PR TITLE
UIINREACH-169: Added transfer status for item cancel hold action

### DIFF
--- a/src/components/transaction/TransactionDetails/components/ActionMenu/components/ItemActions/ItemActions.js
+++ b/src/components/transaction/TransactionDetails/components/ActionMenu/components/ItemActions/ItemActions.js
@@ -69,7 +69,7 @@ const ItemActions = ({
         onClickHandler={onRecallItem}
       />
       <ActionItem
-        disabled={![ITEM_HOLD].includes(transaction[STATUS])}
+        disabled={![ITEM_HOLD, TRANSFER].includes(transaction[STATUS])}
         icon={ICONS.TIMES_CIRCLE}
         buttonTextTranslationKey="ui-inn-reach.transaction-detail.item-type.action.cancel-hold"
         onToggle={onToggle}

--- a/src/components/transaction/TransactionDetails/components/ActionMenu/components/ItemActions/ItemActions.test.js
+++ b/src/components/transaction/TransactionDetails/components/ActionMenu/components/ItemActions/ItemActions.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { screen } from '@testing-library/react';
 import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
 import { translationsProperties } from '../../../../../../../../test/jest/helpers';
 import ItemActions from './ItemActions';
@@ -27,6 +28,28 @@ const renderItemActions = ({
 };
 
 describe('ItemActions component', () => {
+  describe('cancel item hold', () => {
+    it('should be enabled with ITEM_HOLD state', () => {
+      renderItemActions({
+        transaction: {
+          ...transactionMock,
+          state: 'ITEM_HOLD',
+        },
+      });
+      expect(screen.getByRole('button', { name: 'Icon Cancel hold' })).toBeEnabled();
+    });
+
+    it('should be enabled with TRANSFER state', () => {
+      renderItemActions({
+        transaction: {
+          ...transactionMock,
+          state: 'TRANSFER',
+        },
+      });
+      expect(screen.getByRole('button', { name: 'Icon Cancel hold' })).toBeEnabled();
+    });
+  });
+
   it('should render "check out" action', () => {
     const { getByText } = renderItemActions();
 


### PR DESCRIPTION
# Purpose 
Added transfer state for enabling item cancel actions

# Ref
[UIINREACH-169](https://issues.folio.org/browse/UIINREACH-169)