### PR TITLE
UIINREACH-179 - After entering an invalid server name in the server selection field, the "INN-Reach paging slip templates" panel closes and an error message appears.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-inn-reach
 ## [1.4.0] (IN PROGRESS)
-
+* After entering an invalid server name in the server selection field, the "INN-Reach paging slip templates" panel closes and an error message appears. Refs UIINREACH-179
 ## [1.3.0] (https://github.com/folio-org/ui-inn-reach/tree/v1.3.0) (2022-05-03)
 
 * Added transfer status for item cancel hold action. Refs UIINREACH-169.

--- a/src/hooks/useCentralServers/useCentralServers.js
+++ b/src/hooks/useCentralServers/useCentralServers.js
@@ -27,7 +27,7 @@ const useCentralServers = (history, servers, showModal) => {
   };
 
   const handleServerChange = (selectedServerName) => {
-    if (selectedServerName === selectedServer.name) return;
+    if (!selectedServerName || selectedServerName === selectedServer.name) return;
     const optedServer = servers.find(server => server.name === selectedServerName);
 
     setSelectedServer(optedServer);


### PR DESCRIPTION
## Purpose
After entering an invalid server name in the server selection field, the "INN-Reach paging slip templates" panel closes and an error message appears.

## Issue
[UIINREACH179](https://issues.folio.org/browse/UIINREACH-179)

## Screenshots
![FgqWrhhb0q](https://user-images.githubusercontent.com/104053200/176171706-9072c633-6a4d-4b69-9bca-96dc7d6a59dc.gif)
