### PR TITLE
UIINREACH-188 - The time change is not displayed in the table on the “Check out to borrowing site” screen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change history for ui-inn-reach
 
 ## (in progress)
-
+* update FOLIO_CHECK_OUT_FIELDS. Refs UIINREACH-188.
 ## [2.0.0] (https://github.com/folio-org/ui-inn-reach/tree/v2.0.0) (2022-08-18)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v1.3.0...v2.0.0)
 

--- a/src/components/CheckOutBorrowingSite/components/ListCheckOutItems/ListCheckOutItems.js
+++ b/src/components/CheckOutBorrowingSite/components/ListCheckOutItems/ListCheckOutItems.js
@@ -73,6 +73,7 @@ const ListCheckOutItems = ({
   const items = scannedItems.map((item, index) => ({
     ...item,
     [NO]: index + 1,
+    time: item.dueDate
   }));
 
   const renderActions = (loan) => {

--- a/src/constants/checkout-shipped-items.js
+++ b/src/constants/checkout-shipped-items.js
@@ -2,7 +2,7 @@ export const FOLIO_CHECK_OUT_FIELDS = {
   ITEM: 'item',
   LOAN_POLICY: 'loanPolicy',
   DUE_DATE: 'dueDate',
-  TIME: 'loanDate',
+  TIME: 'time',
 };
 
 export const LOAN_POLICY_FIELDS = {


### PR DESCRIPTION
## Purpose
Issue: [UIINREACH-188](https://issues.folio.org/browse/UIINREACH-188)

## Description
Short description or steps to reproduce 
1. While in 'INN-Reach' application, select "Check out to borrowing site" from select menu on left pane, beneath 'Select activity'
2. Check out an item(associated with ui-inn-reach transaction, in ITEM_HOLD status) in right pane.
3. There will be a table displayed beneath the scsn items form, from the last column 'Actions', select 'Change due data'.
4. Change time in the modal that opens up and click save and close.
5. The time updates on the modal too.
6. Close the modal.
7. The issue is that the new value of time should be displayed on the table in column 'Time'.
## Screenshots
Before
![7qGfn4EMhp](https://user-images.githubusercontent.com/104053200/187203111-42eaf560-38f2-4357-981f-3da42c096774.gif)

After
![chrome_eo2Qnp8THI](https://user-images.githubusercontent.com/104053200/187202084-8d7dc3b6-1502-4c2a-8d85-6fa466cd3393.gif)
