### PR TITLE
Fix import path for @folio/stripes/smart-components

### DIFF
--- a/src/components/common/filters/MultiChoiceFilter/MultiChoiceFilter.js
+++ b/src/components/common/filters/MultiChoiceFilter/MultiChoiceFilter.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import { MultiSelectionFilter } from '@folio/stripes-smart-components';
+import { MultiSelectionFilter } from '@folio/stripes/smart-components';
 import FilterAccordion from '../FilterAccordion';
 
 const MultiChoiceFilter = ({

--- a/src/components/transaction/TransactionDetails/components/TransactionSummary/TransactionSummary.js
+++ b/src/components/transaction/TransactionDetails/components/TransactionSummary/TransactionSummary.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import {
   ViewMetaData,
-} from '@folio/stripes-smart-components';
+} from '@folio/stripes/smart-components';
 import {
   Accordion,
   Row,

--- a/src/settings/components/CentralServersConfiguration/CentralServersConfigurationView/components/GeneralInformation/GeneralInformation.js
+++ b/src/settings/components/CentralServersConfiguration/CentralServersConfigurationView/components/GeneralInformation/GeneralInformation.js
@@ -12,7 +12,7 @@ import {
   NoValue,
   MultiColumnList,
 } from '@folio/stripes/components';
-import { ViewMetaData } from '@folio/stripes-smart-components';
+import { ViewMetaData } from '@folio/stripes/smart-components';
 
 import {
   GENERAL_ACCORDION_NAME,


### PR DESCRIPTION
`stripes-smart-components` modules should be imported as `@folio/stripes/smart-components`
Otherwise it gives errors during Jenkins build:
![image](https://user-images.githubusercontent.com/19309423/195373010-7a4e8400-3330-453d-bc02-e8c90d2b871e.png)
