### PR TITLE
UIINREACH-201 - @folio/plugin-find-user version is incompatible (out of date)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * support `users` interface version `16.0`. Refs UIINREACH-192.
 * update FOLIO_CHECK_OUT_FIELDS. Refs UIINREACH-188.
 * Transactions with a link in the Patron ID field are not included in the list of search results by Patron ID. Fixes UIINREACH-200
+* @folio/plugin-find-user version is incompatible (out of date). Fixes UIINREACH-201
 
 ## [2.0.1] (https://github.com/folio-org/ui-inn-reach/tree/v2.0.1) (2022-09-08)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v2.0.0...v2.0.1)

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^5.0.1"
+    "@folio/plugin-find-user": "^6.3.0"
   },
   "stripes": {
     "actsAs": [


### PR DESCRIPTION
## Purpose
@folio/plugin-find-user version is incompatible (out of date)
Issue: https://issues.folio.org/browse/UIINREACH-201

## Approach
Bumped up @folio/plugin-find-user version in package.json file.
Made basic sanity check by starting the application in local host and also accessing different pages in the module and running the tests.