### PR TITLE
UIINREACH-202 - remove 'query-string' from dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * update FOLIO_CHECK_OUT_FIELDS. Refs UIINREACH-188.
 * Transactions with a link in the Patron ID field are not included in the list of search results by Patron ID. Fixes UIINREACH-200
 * @folio/plugin-find-user version is incompatible (out of date). Fixes UIINREACH-201
+* query-string is incorrectly listed as a peer-dependency. Fixes UIINREACH-202
 
 ## [2.0.1] (https://github.com/folio-org/ui-inn-reach/tree/v2.0.1) (2022-09-08)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v2.0.0...v2.0.1)

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^7.0.0",
-    "query-string": "^5.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "react-final-form": "^6.3.0",
     "react-final-form-arrays": "^3.1.0",
     "react-to-print": "^2.3.2",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "query-string": "^5.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^7.0.0",


### PR DESCRIPTION
## Purpose
query-string is incorrectly listed as a peer-dependency
Issue: https://issues.folio.org/browse/UIINREACH-202