### PR TITLE
UIINREACH-199 - Visible patron ID configuration always includes "User custom fields" selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * update FOLIO_CHECK_OUT_FIELDS. Refs UIINREACH-188.
 * Transactions with a link in the Patron ID field are not included in the list of search results by Patron ID. Fixes UIINREACH-200
 * @folio/plugin-find-user version is incompatible (out of date). Fixes UIINREACH-201
+* Visible patron ID configuration always includes "User custom fields" selected. Fixes UIINREACH-199
 
 ## [2.0.1] (https://github.com/folio-org/ui-inn-reach/tree/v2.0.1) (2022-09-08)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v2.0.0...v2.0.1)

--- a/src/settings/routes/VisiblePatronIdRoute/VisiblePatronIdCreateEditRoute.js
+++ b/src/settings/routes/VisiblePatronIdRoute/VisiblePatronIdCreateEditRoute.js
@@ -69,7 +69,7 @@ const VisiblePatronIdCreateEditRoute = ({
   const customFieldPatronOptions = useMemo(() => getCustomFieldPatronIdentifiers(customFields), [customFields]);
 
   const processInitialValues = (response) => {
-    if (response[USER_C_FIELDS]) {
+    if (response[USER_C_FIELDS].length) {
       setIsCheckedUserCustomField(true);
     }
     const primaryValues = getPrimaryValues(response, customFieldPatronOptions);


### PR DESCRIPTION
## Purpose
Visible patron ID configuration always includes "User custom fields" selected
Issue: UIINREACH-199