### PR TITLE
UIINREACH-205 - "Request too long" report does not include PATRON_HOLD transactions without updated Date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * @folio/plugin-find-user version is incompatible (out of date). Fixes UIINREACH-201
 * query-string is incorrectly listed as a peer-dependency. Fixes UIINREACH-202
 * Visible patron ID configuration always includes "User custom fields" selected. Fixes UIINREACH-199
+* "Request too long" report does not include PATRON_HOLD transactions without updatedDate. Fixes UIINREACH-205
 
 ## [2.0.1] (https://github.com/folio-org/ui-inn-reach/tree/v2.0.1) (2022-09-08)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v2.0.0...v2.0.1)

--- a/src/routes/transaction/utils.js
+++ b/src/routes/transaction/utils.js
@@ -18,6 +18,7 @@ import {
   TRANSACTION_STATUSES,
   TRANSACTION_TYPES,
   FIELDS_OF_REPORT_MODALS,
+  REPORT_TYPES,
 } from '../../constants';
 
 const {
@@ -67,6 +68,7 @@ const {
 } = TRANSACTION_STATUSES;
 
 const {
+  CREATED_DATE,
   UPDATED_DATE,
 } = METADATA_FIELDS;
 
@@ -79,6 +81,8 @@ const GENERAL_PARAMS = {
   [SORT_PARAMETER]: TRANSACTION_LIST_DEFAULT_SORT_FIELD,
   [SORT_ORDER_PARAMETER]: ASC_ORDER,
 };
+
+const { REQUESTED_TOO_LONG } = REPORT_TYPES;
 
 export const formatDateAndTime = (date, formatter) => {
   return date ? formatter(date, { day: 'numeric', month: 'numeric', year: 'numeric' }) : '';
@@ -192,6 +196,9 @@ export const getParamsForRequestedTooLongReport = (record) => {
     [STATUS]: [PATRON_HOLD, TRANSFER],
     [UPDATED_DATE]: getLastModifiedDate(record[MINIMUM_DAYS_REQUESTED]),
     [UPDATED_DATE_OP]: LESS,
+    [CREATED_DATE]: getLastModifiedDate(record[MINIMUM_DAYS_REQUESTED]),
+    [CREATED_DATE_OP]: LESS,
+    [REQUESTED_TOO_LONG]: true
   };
 };
 


### PR DESCRIPTION
## Purpose
"Request too long" report does not include PATRON_HOLD transactions without updatedDate
Issue: https://issues.folio.org/browse/UIINREACH-205