### PR TITLE
UIINREACH-216 Upgrade react-redux to v8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## (3.0.0 in progress)
 * Bump stripes to 8.0.0 for Orchid/2023-R1. Refs. UIINREACH-215
-Upgrade `react-redux` to `v8`. Refs UIINREACH-216.
+* Upgrade `react-redux` to `v8`. Refs UIINREACH-216.
 
 ## [2.0.3] (https://github.com/folio-org/ui-inn-reach/tree/v2.0.3) (2022-12-22)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v2.0.2...v2.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change history for ui-inn-reach
 
-## (in progress)
+## (3.0.0 in progress)
 * Bump stripes to 8.0.0 for Orchid/2023-R1. Refs. UIINREACH-215
+Upgrade `react-redux` to `v8`. Refs UIINREACH-216.
 
 ## [2.0.3] (https://github.com/folio-org/ui-inn-reach/tree/v2.0.3) (2022-12-22)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v2.0.2...v2.0.3)

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@folio/inn-reach",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "description": "Description for inn-reach",
   "main": "src/index.js",
   "repository": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12.20.1"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "start": "stripes serve",
@@ -49,7 +49,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",
-    "react-redux": "^7.2.2",
+    "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.5",
     "regenerator-runtime": "^0.13.3",
@@ -77,7 +77,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",
-    "react-router": "*",
+    "react-redux": "^8.0.5",
+    "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/UIINREACH-216 .
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.