### PR TITLE
UIINREACH-222 - Remove innReachTransaction.pickupLocationPrintName token from staff slips.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change history for ui-inn-reach
 
 ## (in progress)
-
+* Remove innReachTransaction.pickupLocationPrintName token from staff slips. Refs. UIINREACH-222.
 
 ## [3.0.0] (https://github.com/folio-org/ui-inn-reach/tree/v3.0.0) (2022-02-23)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v2.0.3...v3.0.0)

--- a/src/settings/components/PagingSlipTemplate/PagingSlipTemplateForm/getTokens.js
+++ b/src/settings/components/PagingSlipTemplate/PagingSlipTemplateForm/getTokens.js
@@ -65,10 +65,6 @@ const getTokens = () => ({
       previewValue: 'fli02 Agency 1',
     },
     {
-      token: 'innReachTransaction.pickupLocationPrintName',
-      previewValue: 'fl2g1 Delivery Stop',
-    },
-    {
       token: 'innReachTransaction.pickupLocationDeliveryStop',
       previewValue: 'Delivery Stop',
     },


### PR DESCRIPTION
## Purpose
Remove innReachTransaction.pickupLocationPrintName token from staff slips.

## Refs
https://issues.folio.org/browse/UIINREACH-222