### PR TITLE
UIINREACH-236: Owning site paged too long report not honoring "minimum days paged" value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Leverage local `renderWIthIntl` utility for unit tests. Refs. UIINREACH-245.
 * React v19: refactor away from default props for functional components. Refs UIINREACH-235.
+* Owning site paged too long report not honoring "minimum days paged" value. Refs UIINREACH-236.
 
 ## [5.0.0] (https://github.com/folio-org/ui-inn-reach/tree/v5.0.0) (2024-11-21)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v4.2.0...v5.0.0)

--- a/src/routes/transaction/utils.js
+++ b/src/routes/transaction/utils.js
@@ -74,6 +74,7 @@ const {
 
 const {
   LESS,
+  GREATER,
 } = CREATED_DATE_OPERATIONS;
 
 const TOMORROW = 1;
@@ -217,8 +218,8 @@ export const getParamsForOwningSitePagedTooLongReport = (record) => {
     ...GENERAL_PARAMS,
     [TYPE]: [ITEM, LOCAL],
     [STATUS]: [ITEM_HOLD, LOCAL_HOLD, TRANSFER],
-    [CREATED_DATE_OP]: getLastModifiedDate(record[MINIMUM_DAYS_PAGED]),
-    [CREATED_DATE_OP]: LESS,
+    [CREATED_DATE]: getLastModifiedDate(record[MINIMUM_DAYS_PAGED]),
+    [CREATED_DATE_OP]: GREATER,
   };
 };
 


### PR DESCRIPTION
Adjust URL params for the corresponding API call: include `createdDate` param with the appropriate date as selected by the user and change `createdDateOp` to be `greater` since we need to match records with date past `createdDate`.

https://folio-org.atlassian.net/browse/UIINREACH-236