### PR TITLE
UIINREACH-246: `FOLIO to INN-Reach locations` settings - filter FOLIO locations by the selected library id, to avoid displaying locations with the same campus but a different library.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-inn-reach
 
+## IN PROGRESS 
+
+* `FOLIO to INN-Reach locations` settings - filter FOLIO locations by the selected library id, to avoid displaying locations with the same campus but a different library. Fixes UIINREACH-246.
+
 ## [6.0.0] (https://github.com/folio-org/ui-inn-reach/tree/v6.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v5.0.0...v6.0.0)
 

--- a/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.test.js
+++ b/src/settings/routes/FolioToInnReachLocations/FolioToInnReachLocationsCreateEditRoute.test.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import { act } from 'react';
 import {
   cloneDeep,
 } from 'lodash';
 import { createMemoryHistory } from 'history';
-import { screen, act } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 import { ConfirmationModal } from '@folio/stripes/components';
 
@@ -410,6 +410,123 @@ describe('FolioToInnReachLocationsCreateEditRoute component', () => {
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[1][0].onChangeMappingType('Locations'); });
       await act(async () => { await FolioToInnReachLocationsForm.mock.calls[2][0].onChangeLibrary(loclibs[3].name); });
       expect(FolioToInnReachLocationsForm.mock.calls[8][0].initialValues).toEqual(recordForLocationMappings);
+    });
+  });
+
+  describe('when the locationMappings is not empty', () => {
+    it('should display FOLIO locations of only the selected library', async () => {
+      const getLocationMappings = jest.fn(() => Promise.resolve({
+        locationMappings: [
+          {
+            id: '95fd9c8b-ed1b-4661-9079-c467c289463c',
+            locationId: 'ff357dab-1446-4e34-a78c-cf0478a10c75',
+          },
+        ],
+        totalRecords: 1,
+      }));
+      const newMutator = cloneDeep(mutatorMock);
+      const newFOLIOLocations = {
+        records: [{
+          locations: [
+            ...locations,
+            {
+              id: 'b0fc186f-5c09-495a-b6db-4654ae5ec95f',
+              campusId: '1a7d928b-4a04-4466-a2e4-3c5cf564cf3f',
+              code: 'code7',
+              libraryId: 'bbb4f74c-1f53-499e-a40d-bf97fc3f58fb',
+              name: 'FOLIOname2',
+            },
+          ],
+        }],
+        isPending: false,
+        failed: false,
+      };
+
+      newMutator.locationMappings.GET = getLocationMappings;
+
+      renderFolioToInnReachLocationsCreateEditRoute({
+        history,
+        resources: {
+          ...resourcesMock,
+          selectedLibraryId: loclibs[1].id,
+          folioLocations: newFOLIOLocations,
+        },
+        mutator: newMutator,
+      });
+
+      await act(async () => FolioToInnReachLocationsForm.mock.calls[0][0].onChangeServer(servers[0].name));
+      await act(async () => FolioToInnReachLocationsForm.mock.calls.at(-1)[0].onChangeMappingType('Locations'));
+      await act(async () => FolioToInnReachLocationsForm.mock.calls.at(-1)[0].onChangeLibrary(loclibs[3].name));
+
+      expect(FolioToInnReachLocationsForm).toHaveBeenCalledWith(expect.objectContaining({
+        initialValues: {
+          locationsTabularList: [
+            {
+              folioLocation: 'folioName5 (code5)',
+              code: 'code5',
+            },
+            {
+              folioLocation: 'FOLIOname1 (7sdfe)',
+              code: '7sdfe',
+            }
+          ],
+        },
+      }), {});
+    });
+  });
+
+  describe('when the locationMappings is empty', () => {
+    it('should display FOLIO locations of only the selected library', async () => {
+      const getLocationMappings = jest.fn(() => Promise.resolve(locationMappingsResponseMock));
+      const newMutator = cloneDeep(mutatorMock);
+      const locationsOfFOLIO = {
+        records: [{
+          locations: [
+            ...locations,
+            {
+              id: 'b0fc186f-5c09-495a-b6db-4654ae5ec95f',
+              campusId: '1a7d928b-4a04-4466-a2e4-3c5cf564cf3f',
+              code: 'code7',
+              libraryId: 'bbb4f74c-1f53-499e-a40d-bf97fc3f58fb',
+              name: 'FOLIOname2',
+            },
+          ],
+        }],
+        isPending: false,
+        failed: false,
+      };
+
+      newMutator.locationMappings.GET = getLocationMappings;
+
+      renderFolioToInnReachLocationsCreateEditRoute({
+        history,
+        resources: {
+          ...resourcesMock,
+          selectedLibraryId: loclibs[1].id,
+          folioLocations: locationsOfFOLIO,
+        },
+        mutator: newMutator,
+      });
+
+      await act(async () => FolioToInnReachLocationsForm.mock.calls[0][0].onChangeServer(servers[0].name));
+      await act(async () => FolioToInnReachLocationsForm.mock.calls.at(-1)[0].onChangeMappingType('Locations'));
+      await act(async () => FolioToInnReachLocationsForm.mock.calls.at(-1)[0].onChangeLibrary(loclibs[3].name));
+
+      expect(FolioToInnReachLocationsForm).toHaveBeenCalledWith(expect.objectContaining({
+        initialValues: {
+          locationsTabularList: [
+            {
+              folioLocation: 'folioName5 (code5)',
+              innReachLocations: '7fab623d-1947-4413-b315-eae9ba9bb0c0',
+              code: 'code5',
+            },
+            {
+              folioLocation: 'FOLIOname1 (7sdfe)',
+              code: '7sdfe',
+            },
+          ],
+        },
+      }), {});
     });
   });
 

--- a/src/settings/routes/FolioToInnReachLocations/utils.js
+++ b/src/settings/routes/FolioToInnReachLocations/utils.js
@@ -147,14 +147,20 @@ export const getLibrariesMappingsMap = (libraryMappings) => {
   return libraryMappingsMap;
 };
 
+const getFOLIOLocationsOfOptedLibrary = (folioLocations, selectedLibraryId) => {
+  return folioLocations.filter(location => location.libraryId === selectedLibraryId);
+};
+
 export const getLeftColumnLocations = ({
   selectedLibraryId,
   folioLocations,
   folioLibraries,
 }) => {
   const selectedLibraryCampusId = getCampusId({ selectedLibraryId, folioLibraries });
+  // several libraries can have the same campus, so we also need to filter locations by the selected library id
+  const folioLocationsOfOptedLibrary = getFOLIOLocationsOfOptedLibrary(folioLocations, selectedLibraryId);
 
-  return folioLocations.reduce((accum, { name, code, campusId }) => {
+  return folioLocationsOfOptedLibrary.reduce((accum, { name, code, campusId }) => {
     if (campusId === selectedLibraryCampusId) {
       accum.push({
         [FOLIO_LOCATION]: `${name} (${code})`,
@@ -192,8 +198,10 @@ export const getTabularListForLocations = ({
   folioLibraries,
 }) => {
   const selectedLibraryCampusId = getCampusId({ selectedLibraryId, folioLibraries });
+  // several libraries can have the same campus, so we also need to filter locations by the selected library id
+  const folioLocationsOfOptedLibrary = getFOLIOLocationsOfOptedLibrary(folioLocations, selectedLibraryId);
 
-  return folioLocations.reduce((accum, { id, name, code, campusId }) => {
+  return folioLocationsOfOptedLibrary.reduce((accum, { id, name, code, campusId }) => {
     if (campusId === selectedLibraryCampusId) {
       const option = {
         [FOLIO_LOCATION]: `${name} (${code})`,

--- a/src/settings/routes/FolioToInnReachLocations/utils.js
+++ b/src/settings/routes/FolioToInnReachLocations/utils.js
@@ -46,13 +46,6 @@ export const getServerLibraries = (localAgencies, folioLibraries) => {
   return formattedLibraries;
 };
 
-const getCampusId = ({
-  selectedLibraryId,
-  folioLibraries,
-}) => {
-  return folioLibraries.find(library => library.id === selectedLibraryId).campusId;
-};
-
 export const getFinalLocationMappings = ({
   folioLocations,
   tabularListMap,
@@ -147,8 +140,12 @@ export const getLibrariesMappingsMap = (libraryMappings) => {
   return libraryMappingsMap;
 };
 
-const getFOLIOLocationsOfOptedLibrary = (folioLocations, selectedLibraryId) => {
-  return folioLocations.filter(location => location.libraryId === selectedLibraryId);
+const filterLocationsByLibraryAndCampusId = (folioLibraries, folioLocations, selectedLibraryId) => {
+  const selectedLibraryCampusId = folioLibraries.find(library => library.id === selectedLibraryId).campusId;
+
+  return folioLocations
+    .filter(({ libraryId }) => libraryId === selectedLibraryId)
+    .filter(({ campusId }) => campusId === selectedLibraryCampusId);
 };
 
 export const getLeftColumnLocations = ({
@@ -156,20 +153,12 @@ export const getLeftColumnLocations = ({
   folioLocations,
   folioLibraries,
 }) => {
-  const selectedLibraryCampusId = getCampusId({ selectedLibraryId, folioLibraries });
-  // several libraries can have the same campus, so we also need to filter locations by the selected library id
-  const folioLocationsOfOptedLibrary = getFOLIOLocationsOfOptedLibrary(folioLocations, selectedLibraryId);
+  const filteredLocations = filterLocationsByLibraryAndCampusId(folioLibraries, folioLocations, selectedLibraryId);
 
-  return folioLocationsOfOptedLibrary.reduce((accum, { name, code, campusId }) => {
-    if (campusId === selectedLibraryCampusId) {
-      accum.push({
-        [FOLIO_LOCATION]: `${name} (${code})`,
-        [CODE]: code,
-      });
-    }
-
-    return accum;
-  }, []);
+  return filteredLocations.map(({ name, code }) => ({
+    [FOLIO_LOCATION]: `${name} (${code})`,
+    [CODE]: code,
+  }));
 };
 
 const getFolioLibraryIdsSet = (folioLibraryIds) => {
@@ -197,29 +186,24 @@ export const getTabularListForLocations = ({
   folioLocations,
   folioLibraries,
 }) => {
-  const selectedLibraryCampusId = getCampusId({ selectedLibraryId, folioLibraries });
-  // several libraries can have the same campus, so we also need to filter locations by the selected library id
-  const folioLocationsOfOptedLibrary = getFOLIOLocationsOfOptedLibrary(folioLocations, selectedLibraryId);
+  const filteredLocations = filterLocationsByLibraryAndCampusId(folioLibraries, folioLocations, selectedLibraryId);
 
-  return folioLocationsOfOptedLibrary.reduce((accum, { id, name, code, campusId }) => {
-    if (campusId === selectedLibraryCampusId) {
-      const option = {
-        [FOLIO_LOCATION]: `${name} (${code})`,
-        [CODE]: code,
-      };
-      const isCodeSelected = locMappingsMap.has(id);
+  return filteredLocations.map(({ id, name, code }) => {
+    const option = {
+      [FOLIO_LOCATION]: `${name} (${code})`,
+      [CODE]: code,
+    };
 
-      if (isCodeSelected) {
-        const innReachLocationId = locMappingsMap.get(id).innReachLocationId;
+    const isCodeSelected = locMappingsMap.has(id);
 
-        option[INN_REACH_LOCATIONS] = innReachLocationId;
-      }
+    if (isCodeSelected) {
+      const innReachLocationId = locMappingsMap.get(id).innReachLocationId;
 
-      accum.push(option);
+      option[INN_REACH_LOCATIONS] = innReachLocationId;
     }
 
-    return accum;
-  }, []);
+    return option;
+  });
 };
 
 export const getLibrariesTabularList = ({


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIINREACH-1 Create INN-Reach Settings
-->

## Purpose
Show locations of only the selected library in the "FOLIO to INN-Reach locations" settings.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIINREACH-1
 -->

## Approach
Filter locations by the selected library.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->


## Screencasts

https://github.com/user-attachments/assets/620b4159-f0f6-4c14-bbbe-33fc8380d4fd



## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
