### PR TITLE
UIINREACH-274: Circulation User for INN-Reach patron type mapping interface only displays 10 results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Migrate tests to `@folio/jest-config-stripes` from the `@testing-library/*` packages. Refs UIINREACH-266.
 * Add `stripes-core.settings.read` permission to app and settings permissions. Refs UIINREACH-269.
 * Bump `@folio/stripes-data-transfer-components` to v7 for compatibility. Refs UIINREACH-276.
+* Add `limit` query parameter for the central patron type mappings, patron types, and local servers requests. Fixes UIINREACH-274.
 
 ## [6.0.2] (https://github.com/folio-org/ui-inn-reach/tree/v6.0.2) (2025-09-08)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v6.0.1...v6.0.2)

--- a/src/constants/base.js
+++ b/src/constants/base.js
@@ -52,3 +52,5 @@ export const DATE_FORMAT = 'YYYY-MM-DD';
 export const ICON_KEYS = {
   APP: 'app',
 };
+
+export const LIMIT = 2000;

--- a/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.js
+++ b/src/settings/routes/AgencyToFolioLocations/AgencyToFolioLocationsCreateEditRoute.js
@@ -23,6 +23,7 @@ import {
   CALLOUT_ERROR_TYPE,
   AGENCY_TO_FOLIO_LOCATIONS_FIELDS,
   CENTRAL_SERVERS_LIMITING,
+  LIMIT,
 } from '../../../constants';
 import {
   getFolioLocationOptions,
@@ -394,7 +395,7 @@ AgencyToFolioLocationsCreateEditRoute.manifest = Object.freeze({
   },
   localServers: {
     type: 'okapi',
-    path: 'inn-reach/central-servers/%{selectedServerId}/d2r/contribution/localservers',
+    path: `inn-reach/central-servers/%{selectedServerId}/d2r/contribution/localservers?limit=${LIMIT}`,
     accumulate: true,
     fetch: false,
     throwErrors: false,

--- a/src/settings/routes/FolioCirculationUserRoute/FolioCirculationUserCreateEditRoute.js
+++ b/src/settings/routes/FolioCirculationUserRoute/FolioCirculationUserCreateEditRoute.js
@@ -16,6 +16,7 @@ import {
   CALLOUT_ERROR_TYPE,
   FOLIO_CIRCULATION_USER_FIELDS,
   CENTRAL_SERVERS_LIMITING,
+  LIMIT,
 } from '../../../constants';
 import {
   getCentralServerOptions,
@@ -168,14 +169,14 @@ FolioCirculationUserCreateEditRoute.manifest = Object.freeze({
   },
   centralPatronTypeMappings: {
     type: 'okapi',
-    path: 'inn-reach/central-servers/%{selectedServerId}/central-patron-type-mappings',
+    path: `inn-reach/central-servers/%{selectedServerId}/central-patron-type-mappings?limit=${LIMIT}`,
     accumulate: true,
     fetch: false,
     throwErrors: false,
   },
   innReachPatronTypes: {
     type: 'okapi',
-    path: 'inn-reach/central-servers/%{selectedServerId}/d2r/circ/patrontypes',
+    path: `inn-reach/central-servers/%{selectedServerId}/d2r/circ/patrontypes?limit=${LIMIT}`,
     accumulate: true,
     fetch: false,
     throwErrors: false,


### PR DESCRIPTION
## Purpose

The FOLIO circulation user for INN-Reach patron type mapping interface only displayed a maximum of 10 results due to the default API limit.

## Description

Added a `limit` query parameter (set to 2000) to the API requests for central patron type mappings, patron types, and local servers to ensure all records are returned.

## Issues

[UIINREACH-274](https://folio-org.atlassian.net/browse/UIINREACH-274)