### PR TITLE
UIINREACH-265: Disable sorting by Item Title and Patron Name columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `stripes-core.settings.read` permission to app and settings permissions. Refs UIINREACH-269.
 * Bump `@folio/stripes-data-transfer-components` to v7 for compatibility. Refs UIINREACH-276.
 * Add `limit` query parameter for the central patron type mappings, patron types, and local servers requests. Fixes UIINREACH-274.
+* Disable sorting by Item Title and Patron Name columns as the backend does not support these sort fields. Fixes UIINREACH-265.
 
 ## [6.0.2] (https://github.com/folio-org/ui-inn-reach/tree/v6.0.2) (2025-09-08)
 [Full Changelog](https://github.com/folio-org/ui-inn-reach/compare/v6.0.1...v6.0.2)

--- a/src/components/common/SearchAndFilter/SearchAndFilter.js
+++ b/src/components/common/SearchAndFilter/SearchAndFilter.js
@@ -84,6 +84,7 @@ const SearchAndFilter = ({
   },
   children,
   visibleColumns,
+  nonInteractiveHeaders,
   columnMapping,
   resultsFormatter,
   resultsPaneTitle,
@@ -353,12 +354,14 @@ const SearchAndFilter = ({
         <MultiColumnList
           autosize
           virtualize
+          showSortIndicator
           columnMapping={columnMapping}
           contentData={contentData}
           formatter={resultsFormatter}
           id={id}
           isEmptyMessage={resultsStatusMessage}
           loading={isLoading}
+          nonInteractiveHeaders={nonInteractiveHeaders}
           sortDirection={`${sortingDirection}ending`}
           sortOrder={sortingField}
           totalCount={count}
@@ -403,6 +406,7 @@ SearchAndFilter.propTypes = {
   isLoading: PropTypes.bool,
   isPreRenderAllData: PropTypes.bool,
   isShowAddNew: PropTypes.bool,
+  nonInteractiveHeaders: PropTypes.array,
 };
 
 export default withRouter(SearchAndFilter);

--- a/src/components/transaction/TransactionList/transaction-list.js
+++ b/src/components/transaction/TransactionList/transaction-list.js
@@ -32,6 +32,11 @@ const visibleColumns = [
   TRANSACTION_FIELDS.STATUS,
 ];
 
+const nonInteractiveHeaders = [
+  TRANSACTION_FIELDS.ITEM_TITLE,
+  TRANSACTION_FIELDS.PATRON_NAME,
+];
+
 const columnMapping = {
   [TRANSACTION_FIELDS.TIME]: <FormattedMessage id="ui-inn-reach.transaction.field.time" />,
   [TRANSACTION_FIELDS.TYPE]: <FormattedMessage id="ui-inn-reach.transaction.field.type" />,
@@ -132,6 +137,7 @@ const TransactionListView = ({
       id="transactions-list"
       isLoading={isLoading}
       isShowAddNew={false}
+      nonInteractiveHeaders={nonInteractiveHeaders}
       resetData={resetData}
       pagingSlipsArr={pagingSlipsArr}
       pagingSlipTemplatesMap={pagingSlipTemplatesMap}


### PR DESCRIPTION
## Purpose

Sorting by the "Item Title" or "Patron Name" columns triggers a 400 validation error from the backend because `title` and `patronName` are not part of the `sortBy` enum in `InnReachTransactionFilterParametersDTO`.

## Approach

The "Item Title" and "Patron Name" column headers are made non-interactive (non-sortable) via the `nonInteractiveHeaders` prop on `MultiColumnList`. This prevents the invalid `sortBy` value from being sent to the backend without misleading users about sort behavior.

The valid backend sort fields are: `transactionTime`, `createdDate`, `updatedDate`, `type`, `state`, `itemAgencyCode`, `patronAgencyCode`, `centralPatronType`, `centralItemType`.

A long-term fix would require a backend ticket to add `title` and `patronName` to the supported `sortBy` enum.

## Issues

[UIINREACH-265](https://folio-org.atlassian.net/browse/UIINREACH-265)

## Screenshots
<img width="1919" height="971" alt="image" src="https://github.com/user-attachments/assets/44a85a6b-e898-40d1-a702-3bc04b3db9bd" />
